### PR TITLE
Use a time interval based index pattern

### DIFF
--- a/resources/dashboards/Capture-Dashboard.json
+++ b/resources/dashboards/Capture-Dashboard.json
@@ -6,6 +6,6 @@
    "version": 1,
    "timeRestore": false,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"network_*\",\"key\":\"Captured\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Captured\":{\"query\":true,\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
+      "searchSourceJSON": "{\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Captured\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Captured\":{\"query\":true,\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
    }
 }

--- a/resources/searches/Analyze-Table.json
+++ b/resources/searches/Analyze-Table.json
@@ -16,6 +16,6 @@
    ],
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[]}"
    }
 }

--- a/resources/searches/Attachment-Table.json
+++ b/resources/searches/Attachment-Table.json
@@ -16,6 +16,6 @@
   ],
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}}}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}}}"
   }
 }

--- a/resources/searches/Capture-Table.json
+++ b/resources/searches/Capture-Table.json
@@ -17,6 +17,6 @@
    ],
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[]}"
    }
 }

--- a/resources/searches/SMTP-Table.json
+++ b/resources/searches/SMTP-Table.json
@@ -15,6 +15,6 @@
   ],
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}}}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}}}"
   }
 }

--- a/resources/visualizations/Bottom-10-Logins.json
+++ b/resources/visualizations/Bottom-10-Logins.json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Bottom-10-User-Agent-Strings.json
+++ b/resources/visualizations/Bottom-10-User-Agent-Strings.json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/SMTP-Sessions-Over-Time.json
+++ b/resources/visualizations/SMTP-Sessions-Over-Time.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Sessions-With-Attachments-(line-graph).json
+++ b/resources/visualizations/Sessions-With-Attachments-(line-graph).json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Attachment-Names.json
+++ b/resources/visualizations/Top-10-Attachment-Names.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
+++ b/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Attachment-Types-By-Count.json
+++ b/resources/visualizations/Top-10-Attachment-Types-By-Count.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Email-Receivers.json
+++ b/resources/visualizations/Top-10-Email-Receivers.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"ReceiverEmail:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"ReceiverEmail:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Email-Sender-Domains.json
+++ b/resources/visualizations/Top-10-Email-Sender-Domains.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Email-Senders.json
+++ b/resources/visualizations/Top-10-Email-Senders.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"SenderEmail:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"SenderEmail:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Email-Subjects.json
+++ b/resources/visualizations/Top-10-Email-Subjects.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Subject:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Subject:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Logins.json
+++ b/resources/visualizations/Top-10-Logins.json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Top-10-Receivers-By-Count.json
+++ b/resources/visualizations/Top-10-Receivers-By-Count.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Senders-By-Count.json
+++ b/resources/visualizations/Top-10-Senders-By-Count.json
@@ -4,6 +4,6 @@
   "description": "",
   "version": 1,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-User-Agent-Strings.json
+++ b/resources/visualizations/Top-10-User-Agent-Strings.json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Top-Applications-By-Bandwidth-(histogram).json
+++ b/resources/visualizations/Top-Applications-By-Bandwidth-(histogram).json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Top-Applications-By-Bandwidth-(pie).json
+++ b/resources/visualizations/Top-Applications-By-Bandwidth-(pie).json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Top-Applications-By-Duration-(histogram).json
+++ b/resources/visualizations/Top-Applications-By-Duration-(histogram).json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Top-IPs-By-Duration-(histogram).json
+++ b/resources/visualizations/Top-IPs-By-Duration-(histogram).json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
    }
 }

--- a/resources/visualizations/Top-SrcPorts-by-Bandwidth-(histogram).json
+++ b/resources/visualizations/Top-SrcPorts-by-Bandwidth-(histogram).json
@@ -4,6 +4,6 @@
    "description": "",
    "version": 1,
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"index\":\"network_*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
+      "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
    }
 }

--- a/scripts/setDefaultIndex.sh
+++ b/scripts/setDefaultIndex.sh
@@ -32,9 +32,9 @@ index_pattern_exists=$?
 if [ "$index_pattern_exists" -eq "0"  ]; then
    echo `date +'%D %T'` "  Index pattern \"[network_]YYYY_MM_DD\" DOES NOT exist. Creating it now..." >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  POST returned:"                                                            >> $KIBANA_LOG_FILE
-   $CURL -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$CREATE""$PRETTY" -d "$INDEX_PATTERN_SPEC" >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$CREATE""$PRETTY" -d "$INDEX_PATTERN_SPEC"           >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$INDEX_PATTERN$PRETTY:"              >> $KIBANA_LOG_FILE
-   $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                    >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                              >> $KIBANA_LOG_FILE
 else
    echo `date +'%D %T'` "  Index pattern \"[network_]YYYY_MM_DD\" ALREADY EXISTS."                    >> $KIBANA_LOG_FILE
 fi
@@ -57,26 +57,26 @@ fi
 $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN" | grep "$SILENT" "fieldFormatMap"
 field_format_map_exists=$?
 if [ "$field_format_map_exists" -ne "0" ]; then
-   echo `date +'%D %T'` "  Custom fieldFormatMap doesn't exist. Creating it..."            >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  POST returned:"                                                 >> $KIBANA_LOG_FILE
-   $CURL -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$UPDATE" "$JSON_FLAG" @$MAPPINGS           >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$INDEX_PATTERN$PRETTY:"   >> $KIBANA_LOG_FILE
-   $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                    >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Custom fieldFormatMap doesn't exist. Creating it..."                       >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  POST returned:"                                                            >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$UPDATE" "$JSON_FLAG" @$MAPPINGS                     >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$INDEX_PATTERN$PRETTY:"              >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                              >> $KIBANA_LOG_FILE
 else
-   echo `date +'%D %T'` "  Custom fieldFormatMap already exists."                          >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Custom fieldFormatMap already exists."                                     >> $KIBANA_LOG_FILE
 fi
 
 # Specify for our $VER config that the default index should be the newly created "[network_]YYYY_MM_DD" index pattern
 $CURL "$XHEAD_PARAMS" -XHEAD "$KIBANA_PREFIX""$CONFIG" | grep "$SILENT" "$NOT_FOUND"
 config_exists=$?
 if [ "$config_exists" -eq "0"  ]; then
-   echo `date +'%D %T'` "  Config record for $VER DOES NOT exist. Creating it now..."      >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  POST returned:"                                                 >> $KIBANA_LOG_FILE
-   $CURL -XPOST "$KIBANA_PREFIX""$CONFIG""$CREATE""$PRETTY" "$JSON_FLAG" "$DEFAULT_INDEX"   >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$CONFIG$PRETTY:"          >> $KIBANA_LOG_FILE
-   $CURL -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                           >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Config record for $VER DOES NOT exist. Creating it now..."                 >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  POST returned:"                                                            >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$CONFIG""$CREATE""$PRETTY" "$JSON_FLAG" "$DEFAULT_INDEX"             >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$CONFIG$PRETTY:"                     >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                                     >> $KIBANA_LOG_FILE
 else
-   echo `date +'%D %T'` "  Config record for $VER ALREADY EXISTS."                         >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Config record for $VER ALREADY EXISTS."                                    >> $KIBANA_LOG_FILE
 fi
 
 # If you stop XDELETE the kibana index while kibana is still running, it can rebuild the
@@ -86,11 +86,11 @@ fi
 $CURL -XGET "$KIBANA_PREFIX""$CONFIG" | grep "$SILENT" '\"defaultIndex\":\"\[network_\]YYYY_MM_DD\"'
 config_has_default_index=$?
 if [ "$config_has_default_index" -ne "0" ]; then
-   echo `date +'%D %T'` "  Config for $VER exists, but no default index is specified"      >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Config for $VER exists, but no default index is specified"                 >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  Updating config/$VER record with default index \"[network_]YYYY_MM_DD\""   >> $KIBANA_LOG_FILE
-   $CURL -XPOST "$KIBANA_PREFIX""$CONFIG""$UPDATE""$PRETTY" "$JSON_FLAG" "{\"doc\": $DEFAULT_INDEX}" >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$CONFIG$PRETTY:"          >> $KIBANA_LOG_FILE
-   $CURL -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                           >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$CONFIG""$UPDATE""$PRETTY" "$JSON_FLAG" "{\"doc\": $DEFAULT_INDEX}"  >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$CONFIG$PRETTY:"                     >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                                     >> $KIBANA_LOG_FILE
 else
    echo `date +'%D %T'` "  defaultIndex parameter for index pattern \"[network_]YYYY_MM_DD\" is set"  >> $KIBANA_LOG_FILE
 fi

--- a/scripts/setDefaultIndex.sh
+++ b/scripts/setDefaultIndex.sh
@@ -3,7 +3,7 @@
 ES_HEAD="localhost:9200"
 KIBANA_PREFIX="$ES_HEAD/.kibana"
 INDEX_PATTERN="/index-pattern/[network_]YYYY_MM_DD"
-INDEX_PATTERN_SPEC="{\"title\": \"[network_]YYYY_MM_DD\", \"timeFieldName\": \"TimeUpdated\"}"
+INDEX_PATTERN_SPEC="{\"title\": \"[network_]YYYY_MM_DD\", \"timeFieldName\": \"TimeUpdated\", \"intervalName\":\"days\"}"
 DEFAULT_INDEX="{\"defaultIndex\":\"[network_]YYYY_MM_DD\"}"
 VER="4.1.4"
 CONFIG="/config/$VER"

--- a/scripts/setDefaultIndex.sh
+++ b/scripts/setDefaultIndex.sh
@@ -2,9 +2,9 @@
 
 ES_HEAD="localhost:9200"
 KIBANA_PREFIX="$ES_HEAD/.kibana"
-INDEX_PATTERN="/index-pattern/network_*"
-INDEX_PATTERN_SPEC="{\"title\": \"network_*\", \"timeFieldName\": \"TimeUpdated\"}"
-DEFAULT_INDEX="{\"defaultIndex\":\"network_*\"}"
+INDEX_PATTERN="/index-pattern/[network_]YYYY_MM_DD"
+INDEX_PATTERN_SPEC="{\"title\": \"[network_]YYYY_MM_DD\", \"timeFieldName\": \"TimeUpdated\"}"
+DEFAULT_INDEX="{\"defaultIndex\":\"[network_]YYYY_MM_DD\"}"
 VER="4.1.4"
 CONFIG="/config/$VER"
 PRETTY="?pretty"
@@ -18,6 +18,7 @@ JSON_FLAG="-d"
 XHEAD_PARAMS="-i"
 SILENT="-q"
 CASE_INSENS="-i"
+CURL="curl -g" # Glob off for escaping [ ] in index pattern
 
 KIBANA_LOG_FILE="/var/log/probe/KibanaStartup.log"
 
@@ -26,24 +27,24 @@ if [ ! -e $KIBANA_LOG_FILE ]; then
 fi
 
 # Create the index pattern and specify TimeUpdated as the default time parameter
-curl "$XHEAD_PARAMS" -XHEAD "$KIBANA_PREFIX""$INDEX_PATTERN" | grep "$SILENT" "$NOT_FOUND"
+$CURL "$XHEAD_PARAMS" -XHEAD "$KIBANA_PREFIX""$INDEX_PATTERN" | grep "$SILENT" "$NOT_FOUND"
 index_pattern_exists=$?
 if [ "$index_pattern_exists" -eq "0"  ]; then
-   echo `date +'%D %T'` "  Index pattern \"network_*\" DOES NOT exist. Creating it now..." >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  POST returned:"                                                 >> $KIBANA_LOG_FILE
-   curl -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$CREATE""$PRETTY" -d "$INDEX_PATTERN_SPEC" >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$INDEX_PATTERN$PRETTY:"   >> $KIBANA_LOG_FILE
-   curl -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                    >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Index pattern \"[network_]YYYY_MM_DD\" DOES NOT exist. Creating it now..." >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  POST returned:"                                                            >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$CREATE""$PRETTY" -d "$INDEX_PATTERN_SPEC" >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$INDEX_PATTERN$PRETTY:"              >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                    >> $KIBANA_LOG_FILE
 else
-   echo `date +'%D %T'` "  Index pattern \"network_*\" ALREADY EXISTS."                    >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Index pattern \"[network_]YYYY_MM_DD\" ALREADY EXISTS."                    >> $KIBANA_LOG_FILE
 fi
 
 # Check for our custom field mappings
 #
 # BUG NOTICE: When the Kibana service starts, the first thing it does is check its default
 #             index-pattern and re-pull all of that metadata from elasticsearch. In our case,
-#             that means it goes to all the network_* indices and re-caches the field names
-#             and updates the index-pattern/network_* record to reflect the fields it found.
+#             that means it goes to all the [network_]YYYY_MM_DD indices and re-caches the field names
+#             and updates the index-pattern/[network_]YYYY_MM_DD record to reflect the fields it found.
 #
 #             There is a bug in Kibana 4.1 where when a record gets updated, specifically the
 #             key-value pair of "fieldFormatMap" gets overwritten. The bug report for it can
@@ -53,47 +54,43 @@ fi
 #             Fortunately this script checks for the "fieldFormatMap" on every Kibana startup,
 #             so we are always reloading our mappings succesfully. You will see this
 #             reflected in the Kibana startup log.
-curl -XGET "$KIBANA_PREFIX""$INDEX_PATTERN" | grep "$SILENT" "fieldFormatMap"
+$CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN" | grep "$SILENT" "fieldFormatMap"
 field_format_map_exists=$?
 if [ "$field_format_map_exists" -ne "0" ]; then
    echo `date +'%D %T'` "  Custom fieldFormatMap doesn't exist. Creating it..."            >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  POST returned:"                                                 >> $KIBANA_LOG_FILE
-   curl -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$UPDATE" "$JSON_FLAG" @$MAPPINGS           >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$INDEX_PATTERN""$UPDATE" "$JSON_FLAG" @$MAPPINGS           >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$INDEX_PATTERN$PRETTY:"   >> $KIBANA_LOG_FILE
-   curl -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                    >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$INDEX_PATTERN""$PRETTY"                                    >> $KIBANA_LOG_FILE
 else
    echo `date +'%D %T'` "  Custom fieldFormatMap already exists."                          >> $KIBANA_LOG_FILE
 fi
 
-# Specify for our $VER config that the default index should be the newly created "network_*" index pattern
-curl "$XHEAD_PARAMS" -XHEAD "$KIBANA_PREFIX""$CONFIG" | grep "$SILENT" "$NOT_FOUND"
+# Specify for our $VER config that the default index should be the newly created "[network_]YYYY_MM_DD" index pattern
+$CURL "$XHEAD_PARAMS" -XHEAD "$KIBANA_PREFIX""$CONFIG" | grep "$SILENT" "$NOT_FOUND"
 config_exists=$?
 if [ "$config_exists" -eq "0"  ]; then
    echo `date +'%D %T'` "  Config record for $VER DOES NOT exist. Creating it now..."      >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  POST returned:"                                                 >> $KIBANA_LOG_FILE
-   curl -XPOST "$KIBANA_PREFIX""$CONFIG""$CREATE""$PRETTY" "$JSON_FLAG" "$DEFAULT_INDEX"   >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$CONFIG""$CREATE""$PRETTY" "$JSON_FLAG" "$DEFAULT_INDEX"   >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$CONFIG$PRETTY:"          >> $KIBANA_LOG_FILE
-   curl -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                           >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                           >> $KIBANA_LOG_FILE
 else
    echo `date +'%D %T'` "  Config record for $VER ALREADY EXISTS."                         >> $KIBANA_LOG_FILE
 fi
 
 # If you stop XDELETE the kibana index while kibana is still running, it can rebuild the
 #  config type with ID 4.1.4 on its own. We need to check for this and update the record
-#  to include "defaultIndex": "network_*"
+#  to include "defaultIndex": "[network_]YYYY_MM_DD"
 
-curl -XGET "$KIBANA_PREFIX""$CONFIG" | grep "$SILENT" '\"defaultIndex\":\"network_\*\"'
+$CURL -XGET "$KIBANA_PREFIX""$CONFIG" | grep "$SILENT" '\"defaultIndex\":\"\[network_\]YYYY_MM_DD\"'
 config_has_default_index=$?
 if [ "$config_has_default_index" -ne "0" ]; then
    echo `date +'%D %T'` "  Config for $VER exists, but no default index is specified"      >> $KIBANA_LOG_FILE
-   echo `date +'%D %T'` "  Updating config/$VER record with default index \"network_*\""   >> $KIBANA_LOG_FILE
-   curl -XPOST "$KIBANA_PREFIX""$CONFIG""$UPDATE" "$JSON_FLAG" "{\"doc\": $DEFAULT_INDEX}" >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  Updating config/$VER record with default index \"[network_]YYYY_MM_DD\""   >> $KIBANA_LOG_FILE
+   $CURL -XPOST "$KIBANA_PREFIX""$CONFIG""$UPDATE""$PRETTY" "$JSON_FLAG" "{\"doc\": $DEFAULT_INDEX}" >> $KIBANA_LOG_FILE
    echo `date +'%D %T'` "  Result of -> curl -XGET $KIBANA_PREFIX$CONFIG$PRETTY:"          >> $KIBANA_LOG_FILE
-   curl -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                           >> $KIBANA_LOG_FILE
+   $CURL -XGET "$KIBANA_PREFIX""$CONFIG""$PRETTY"                                           >> $KIBANA_LOG_FILE
 else
-   echo `date +'%D %T'` "  defaultIndex parameter for index pattern \"network_*\" is set"  >> $KIBANA_LOG_FILE
+   echo `date +'%D %T'` "  defaultIndex parameter for index pattern \"[network_]YYYY_MM_DD\" is set"  >> $KIBANA_LOG_FILE
 fi
-
-
-
-


### PR DESCRIPTION
Using network_* forces Kibana to go through every index for every request. 

Changing it to network_YYYY_MM_DD and setting our time interval to one day tells Kibana that each index is one days worth of metadata, so the timepicker can do it's job and only pull the data necessary.