### PR TITLE
Refresh Kibana index on Kibana startup

### DIFF
--- a/init/kibana.conf
+++ b/init/kibana.conf
@@ -18,4 +18,5 @@ post-start script
   KB_HOME=/usr/local/kibana-4.1.4-linux-x64/
   sh ${KB_HOME}/setDefaultIndex.sh
   sh ${KB_HOME}/loadAssets.sh
+  sh ${KB_HOME}/refreshKibanaIndex.sh
 end script

--- a/packaging/kibana.spec
+++ b/packaging/kibana.spec
@@ -35,6 +35,7 @@ cp init/kibana.conf %{buildroot}/etc/init
 cp -r resources/ %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/
 cp scripts/setDefaultIndex.sh %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/
 cp scripts/loadAssets.sh %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/
+cp scripts/refreshKibanaIndex.sh %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/
 
 %post
 link=/usr/local/www/probe/%{name}-%{kibana_version}-linux-x64

--- a/scripts/refreshKibanaIndex.sh
+++ b/scripts/refreshKibanaIndex.sh
@@ -1,11 +1,4 @@
 #! /bin/sh
-
-ES_HEAD="localhost:9200"
-KIBANA_PREFIX="$ES_HEAD/.kibana/"
-
-CURL="curl -g"
-REFRESH="/_refresh"
-
 KIBANA_LOG_FILE="/var/log/probe/KibanaStartup.log"
 
 if [ ! -e $KIBANA_LOG_FILE ]; then
@@ -13,4 +6,4 @@ if [ ! -e $KIBANA_LOG_FILE ]; then
 fi
 
 echo `date +'%D %T'` "   Refreshing Kibana index..." >> $KIBANA_LOG_FILE
-$CURL -XPOST "$KIBANA_PREFIX""$REFRESH""$PRETTY"     >> $KIBANA_LOG_FILE
+curl -g -XPOST localhost:9200/.kibana/_refresh?pretty     >> $KIBANA_LOG_FILE

--- a/scripts/refreshKibanaIndex.sh
+++ b/scripts/refreshKibanaIndex.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+ES_HEAD="localhost:9200"
+KIBANA_PREFIX="$ES_HEAD/.kibana/"
+
+CURL="curl -g"
+REFRESH="/_refresh"
+
+KIBANA_LOG_FILE="/var/log/probe/KibanaStartup.log"
+
+if [ ! -e $KIBANA_LOG_FILE ]; then
+   touch $KIBANA_LOG_FILE
+fi
+
+echo `date +'%D %T'` "   Refreshing Kibana index..." >> $KIBANA_LOG_FILE
+$CURL -XPOST "$KIBANA_PREFIX""$REFRESH""$PRETTY"     >> $KIBANA_LOG_FILE


### PR DESCRIPTION
This is the programmatic equivalent to the way that Kjell fixed 10.1.10.244 manually.

.raw fields don't show up because Kibana has not refreshed its knowledge on the metadata indices. By forcing a refresh on startup, Kibana will go through the indices and repopulate the fields it knows about. Since .raw fields should have been created with newer indices, Kibana should now display .raw fields if they were missing before.