### PR TITLE
[MERGE WITH #39] Fixed filters in dashboard

### DIFF
--- a/resources/dashboards/File-Reconstruction-Dashboard.json
+++ b/resources/dashboards/File-Reconstruction-Dashboard.json
@@ -2,10 +2,10 @@
   "title": "File Reconstruction Dashboard",
   "hits": 0,
   "description": "",
-  "panelsJSON": "[{\"id\":\"Top-10-Attachment-Types-(bar-graph)\",\"type\":\"visualization\",\"size_x\":6,\"size_y\":4,\"col\":1,\"row\":1},{\"id\":\"Top-10-Attachment-Names\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":7,\"row\":1},{\"id\":\"Top-10-Senders-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":10,\"row\":1},{\"id\":\"Top-10-Receivers-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":10,\"row\":5},{\"id\":\"Sessions-With-Attachments-(line-graph)\",\"type\":\"visualization\",\"size_x\":6,\"size_y\":4,\"col\":1,\"row\":5},{\"id\":\"Top-10-Attachment-Types-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":7,\"row\":5},{\"id\":\"Attachment-Table\",\"type\":\"search\",\"size_x\":12,\"size_y\":5,\"col\":1,\"row\":9,\"columns\":[\"Attach\",\"SenderEmail\",\"ReceiverEmail\",\"Filename\",\"AttachSize\",\"AttachType\"],\"sort\":[\"TimeUpdated\",\"desc\"]}]",
-  "version": 1,
+  "panelsJSON": "[{\"id\":\"Top-10-Attachment-Types-(bar-graph)\",\"type\":\"visualization\",\"size_x\":6,\"size_y\":4,\"col\":1,\"row\":1},{\"id\":\"Top-10-Attachment-Names\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":7,\"row\":1},{\"id\":\"Top-10-Senders-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":10,\"row\":1},{\"id\":\"Top-10-Receivers-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":10,\"row\":5},{\"id\":\"Top-10-Attachment-Types-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":7,\"row\":5},{\"id\":\"Attachment-Table\",\"type\":\"search\",\"size_x\":12,\"size_y\":5,\"col\":1,\"row\":9,\"columns\":[\"Attach\",\"SenderEmail\",\"ReceiverEmail\",\"Filename\",\"AttachSize\",\"AttachType\"],\"sort\":[\"TimeUpdated\",\"desc\"]},{\"id\":\"Sessions-Over-Time\",\"type\":\"visualization\",\"size_x\":6,\"size_y\":4,\"col\":1,\"row\":5}]",
+  "version": 2,
   "timeRestore": false,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
+    "searchSourceJSON": "{\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Attach\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Attach\":{\"query\":true,\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
   }
 }

--- a/resources/dashboards/SMTP-Trends-Dashboard.json
+++ b/resources/dashboards/SMTP-Trends-Dashboard.json
@@ -2,10 +2,10 @@
   "title": "SMTP Trends Dashboard",
   "hits": 0,
   "description": "",
-  "panelsJSON": "[{\"id\":\"Top-10-Email-Senders\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":7,\"row\":1},{\"id\":\"Top-10-Email-Subjects\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":7,\"row\":4},{\"id\":\"Top-10-Email-Sender-Domains\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":10,\"row\":4},{\"id\":\"SMTP-Sessions-Over-Time\",\"type\":\"visualization\",\"size_x\":6,\"size_y\":6,\"col\":1,\"row\":1},{\"id\":\"SMTP-Table\",\"type\":\"search\",\"size_x\":12,\"size_y\":6,\"col\":1,\"row\":7,\"columns\":[\"Attach\",\"SenderEmail\",\"ReceiverEmail\",\"Subject\",\"TotalBytes\"],\"sort\":[\"TimeUpdated\",\"desc\"]},{\"id\":\"Top-10-Attachment-Types-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":10,\"row\":1}]",
-  "version": 1,
+  "panelsJSON": "[{\"id\":\"Top-10-Email-Senders\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":7,\"row\":1},{\"id\":\"Top-10-Email-Subjects\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":7,\"row\":4},{\"id\":\"Top-10-Email-Sender-Domains\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":10,\"row\":4},{\"id\":\"SMTP-Table\",\"type\":\"search\",\"size_x\":12,\"size_y\":6,\"col\":1,\"row\":7,\"columns\":[\"Attach\",\"SenderEmail\",\"ReceiverEmail\",\"Subject\",\"TotalBytes\"],\"sort\":[\"TimeUpdated\",\"desc\"]},{\"id\":\"Top-10-Attachment-Types-By-Count\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":3,\"col\":10,\"row\":1},{\"id\":\"Sessions-Over-Time\",\"type\":\"visualization\",\"size_x\":6,\"size_y\":6,\"col\":1,\"row\":1}]",
+  "version": 2,
   "timeRestore": false,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
+    "searchSourceJSON": "{\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Application\",\"value\":\"smtp\",\"disabled\":false},\"query\":{\"match\":{\"Application\":{\"query\":\"smtp\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
   }
 }

--- a/resources/searches/Attachment-Table.json
+++ b/resources/searches/Attachment-Table.json
@@ -14,8 +14,8 @@
     "TimeUpdated",
     "desc"
   ],
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}}}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Attach\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Attach\":{\"query\":true,\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
   }
 }

--- a/resources/searches/SMTP-Table.json
+++ b/resources/searches/SMTP-Table.json
@@ -13,8 +13,8 @@
     "TimeUpdated",
     "desc"
   ],
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}}}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Application\",\"value\":\"smtp\",\"disabled\":false},\"query\":{\"match\":{\"Application\":{\"query\":\"smtp\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
   }
 }

--- a/resources/visualizations/SMTP-Sessions-Over-Time.json
+++ b/resources/visualizations/SMTP-Sessions-Over-Time.json
@@ -1,9 +1,0 @@
-{
-  "title": "SMTP Sessions Over Time",
-  "visState": "{\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"TimeUpdated\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
-  "description": "",
-  "version": 1,
-  "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
-  }
-}

--- a/resources/visualizations/Sessions-Over-Time.json
+++ b/resources/visualizations/Sessions-Over-Time.json
@@ -1,9 +1,9 @@
 {
-  "title": "Sessions With Attachments (line graph)",
+  "title": "Sessions Over Time",
   "visState": "{\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"TimeUpdated\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Attachment-Names.json
+++ b/resources/visualizations/Top-10-Attachment-Names.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Attachment Names",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"Filename.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Attachment-Names.json
+++ b/resources/visualizations/Top-10-Attachment-Names.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Attachment Names",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"Filename.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 2,
+  "version": 1,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
+++ b/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
@@ -2,7 +2,7 @@
   "title": "Top 10 Attachment Types (bar graph)",
   "visState": "{\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"AttachSize\"}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"TimeUpdated\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"AttachType.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
+++ b/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
@@ -1,9 +1,9 @@
 {
-  "title": "Top 10 Attachment Types (bar graph)",
-  "visState": "{\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"AttachSize\"}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"TimeUpdated\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"AttachType.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
-  "description": "",
-  "version": 2,
-  "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
-  }
+   "title": "Top 10 Attachment Types (bar graph)",
+   "visState": "{\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"AttachSize\"}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"AttachType.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"TimeUpdated\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+   "description": "",
+   "version": 1,
+   "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+   }
 }

--- a/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
+++ b/resources/visualizations/Top-10-Attachment-Types-(bar-graph).json
@@ -2,7 +2,7 @@
    "title": "Top 10 Attachment Types (bar graph)",
    "visState": "{\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"AttachSize\"}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"AttachType.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"TimeUpdated\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
    "description": "",
-   "version": 1,
+   "version": 2,
    "kibanaSavedObjectMeta": {
         "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
    }

--- a/resources/visualizations/Top-10-Attachment-Types-By-Count.json
+++ b/resources/visualizations/Top-10-Attachment-Types-By-Count.json
@@ -2,8 +2,8 @@
   "title": "Top 10 Attachment Types By Count",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"AttachType.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Email-Sender-Domains.json
+++ b/resources/visualizations/Top-10-Email-Sender-Domains.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Email Sender Domains",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"SenderDomain.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 2,
+  "version": 1,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Email-Sender-Domains.json
+++ b/resources/visualizations/Top-10-Email-Sender-Domains.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Email Sender Domains",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"SenderDomain.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Application:smtp\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Email-Senders.json
+++ b/resources/visualizations/Top-10-Email-Senders.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Email Senders",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"SenderEmail.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"SenderEmail:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Email-Senders.json
+++ b/resources/visualizations/Top-10-Email-Senders.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Email Senders",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"SenderEmail.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 2,
+  "version": 1,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"SenderEmail:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Email-Subjects.json
+++ b/resources/visualizations/Top-10-Email-Subjects.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Email Subjects",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"Subject.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 2,
+  "version": 1,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Subject:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Email-Subjects.json
+++ b/resources/visualizations/Top-10-Email-Subjects.json
@@ -2,7 +2,7 @@
   "title": "Top 10 Email Subjects",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"Subject.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Subject:*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }

--- a/resources/visualizations/Top-10-Receivers-By-Count.json
+++ b/resources/visualizations/Top-10-Receivers-By-Count.json
@@ -2,8 +2,8 @@
   "title": "Top 10 Receivers By Count",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"ReceiverEmail.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }

--- a/resources/visualizations/Top-10-Senders-By-Count.json
+++ b/resources/visualizations/Top-10-Senders-By-Count.json
@@ -2,8 +2,8 @@
   "title": "Top 10 Senders By Count",
   "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"SenderEmail.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
   "description": "",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"Attach:true\",\"analyze_wildcard\":true}},\"filter\":[]}"
+    "searchSourceJSON": "{\"index\":\"[network_]YYYY_MM_DD\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
   }
 }


### PR DESCRIPTION
Changed File Reconstruction Dashboard and SMTP Trends dashboard to use filters instead of a specific search in the visualization. Ran on VM (didn't have SMTP or File Recon traffic) and the filters were there. 

Please pull down and double check that it works on a system with SMTP and File Recon traffic. 

Also fixed Top 10 Attachment Types (bar graph), it was displaying more than the top 10. 

Merge after Craig's PR: https://github.com/LogRhythm/kibana/pull/39