### PR TITLE
Field Format Map 

### DIFF
--- a/resources/mappings.json
+++ b/resources/mappings.json
@@ -2,9 +2,9 @@
 	"fieldFormatMap": {
 		"Duration": {
 			"id":"number",
-				"params": {
-					"pattern":"00:00:00"
-				}
+			"params": {
+				"pattern":"00:00:00"
+			}
 		},
 		"AttachSize": {
 			"id": "bytes"

--- a/resources/mappings.json
+++ b/resources/mappings.json
@@ -1,33 +1,31 @@
 {
-   "doc":{
-      "fieldFormatMap": "{
-         \"Duration\": {
-            \"id\":\"number\",
-               \"params\": {
-                  \"pattern\":\"00:00:00\"
-               }
-         },
-         \"AttachSize\": {
-            \"id\": \"bytes\"
-         },
-         \"TotalBytesDelta\": {
-            \"id\": \"bytes\"
-         },
-         \"TotalBytes\": {
-            \"id\":\"bytes\"
-         },
-         \"SrcBytes\": {
-            \"id\":\"bytes\"
-         },
-         \"SrcBytesDelta\": {
-            \"id\":\"bytes\"
-         },
-         \"DestBytes\": {
-            \"id\":\"bytes\"
-         },
-         \"DestBytesDelta\": {
-            \"id\":\"bytes\"
-         }
-      }"
-   }
+	"fieldFormatMap": {
+		"Duration": {
+			"id":"number",
+				"params": {
+					"pattern":"00:00:00"
+				}
+		},
+		"AttachSize": {
+			"id": "bytes"
+		},
+		"TotalBytesDelta": {
+			"id": "bytes"
+		},
+		"TotalBytes": {
+			"id":"bytes"
+		},
+		"SrcBytes": {
+			"id":"bytes"
+		},
+		"SrcBytesDelta": {
+			"id":"bytes"
+		},
+		"DestBytes": {
+			"id":"bytes"
+		},
+		"DestBytesDelta": {
+			"id":"bytes"
+		}
+	}
 }

--- a/scripts/setDefaultIndex.py
+++ b/scripts/setDefaultIndex.py
@@ -47,15 +47,40 @@ def add_missing_elements_to_dict(to_verify, original_content):
             missing_elements[key] = original_content[key]
     return missing_elements
 
+# When inserting our mappings into the index-pattern document, the json object can have as many nested
+#    objects as needed and insertion will handle it appropriately. However, when searching through the
+#    index pattern after it has been inserted into Elasticsearch (to verify that every field is actually
+#    there), the search requests cannot have a nested json object. The formatting for searching for a
+#    nested object is as follows:
+#
+#    es.search(index, type, key1.key2.keyN:"valueN")
+#
+# EXAMPLE:
+# {
+#  "key1": "value1",
+#  "key2": {
+#      "key3": "value3"
+#   }
+# }
+#
+# This example json object would get flattened and returned by this function as follows:
+#
+# {
+#   "key1": "value1",
+#   "key2.key3": "value3"
+# }
+#
 def flatten_dict(d):
     def items():
         for key, value in d.items():
             if isinstance(value, dict):
                 for subkey, subvalue in flatten_dict(value).items():
                     yield key + "." + subkey, subvalue
+            # If a top-level key is not nested, it is returned exactly
+            # as it is with no dotted notation. As seen in the above
+            # commented example with "key1"
             else:
                 yield key, value
-
     return dict(items())
 
 def verify_document_for_content(es_index, es_type, content):

--- a/scripts/setDefaultIndex.py
+++ b/scripts/setDefaultIndex.py
@@ -16,39 +16,12 @@ NM_INDEX_PATTERN='[network_]YYYY_MM_DD'
 DEFAULT_INDEX='"defaultIndex": \"%s\"' % NM_INDEX_PATTERN
 VERIFIED = 1
 
+FIELD_FORMAT_MAPPINGS_FILE = "usr/local/kibana-" + esUtil.KIBANA_VERSION + "-linux-x64/resources/mappings.json"
+
 index_pattern_content = {
     "title": "[network_]YYYY_MM_DD",
     "intervalName": "days",
-    "timeFieldName": "TimeUpdated",
-    "fieldFormatMap": {
-      "Duration": {
-        "id":"number",
-        "params": {
-            "pattern":"00:00:00"
-        }
-      },
-      "AttachSize": {
-        "id": "bytes"
-      },
-      "TotalBytesDelta": {
-        "id": "bytes"
-      },
-      "TotalBytes": {
-        "id":"bytes"
-      },
-      "SrcBytes": {
-        "id":"bytes"
-      },
-      "SrcBytesDelta": {
-        "id":"bytes"
-      },
-      "DestBytes": {
-        "id":"bytes"
-      },
-      "DestBytesDelta": {
-        "id":"bytes"
-      }
-    }
+    "timeFieldName": "TimeUpdated"
 }
 
 version_config_content = {
@@ -134,9 +107,17 @@ def create_document_if_it_doesnt_exist(es_index, es_type, es_id, es_body):
         logging.info("Document %s/%s/%s/%s already exists.", esUtil.LOCALHOST, es_index, es_type, es_id)
         return document_created
 
+def get_field_mappings(filename):
+    global index_pattern_content
+    mappings_json = UTIL.read_json_from_file(filename)
+    index_pattern_content.update(mappings_json)
+
 
 # ----------------- MAIN -----------------
 def main():
+
+    # Add fieldFormatMap to index-pattern content
+    get_field_mappings(filename=FIELD_FORMAT_MAPPINGS_FILE)
 
     logging.info("================================== INDEX PATTERN ==================================")
     index_pattern_doc_created = create_document_if_it_doesnt_exist(esUtil.KIBANA_INDEX,


### PR DESCRIPTION
The mappings.json file that is copied into /usr/local/kibana is now absorbed into the list of fields that we need to insert into the index pattern and verify afterwards.

A new function condenses the nested json mapping object into a flat dictionary for searching ( ```"fieldFormatMap.AttachSize.id" : "bytes"``` rather than ```"fieldFormatMap": { "AttachSize": { "id": "bytes" } }"```