### PR TITLE
Field Format Map Updates

### DIFF
--- a/scripts/setDefaultIndex.py
+++ b/scripts/setDefaultIndex.py
@@ -48,65 +48,13 @@ def add_missing_elements_to_dict(to_verify, original_content):
             missing_elements[key] = original_content[key]
     return missing_elements
 
-# When inserting our mappings into the index-pattern document, the json object can have as many nested
-#    objects as needed and insertion will handle it appropriately. However, when searching through the
-#    index pattern after it has been inserted into Elasticsearch (to verify that every field is actually
-#    there), the search requests cannot have a nested json object. The formatting for searching for a
-#    nested object is as follows:
-#
-#    es.search(index, type, key1.key2.keyN:"valueN")
-#
-# EXAMPLE:
-# {
-#  "key1": "value1",
-#  "key2": {
-#      "key3": "value3"
-#   }
-# }
-#
-# This example json object would get flattened and returned by this function as follows:
-#
-# {
-#   "key1": "value1",
-#   "key2.key3": "value3"
-# }
-#
-def flatten_dict(d):
-    def items():
-        for key, value in d.items():
-            if isinstance(value, dict):
-                for subkey, subvalue in flatten_dict(value).items():
-                    yield key + "." + subkey, subvalue
-            # If a top-level key is not nested, it is returned exactly
-            # as it is with no dotted notation. As seen in the above
-            # commented example with "key1"
-            else:
-                yield key, value
-    return dict(items())
-
 def replace_all_char(str, to_replace, new_char):
   return str.replace(to_replace, new_char)
 
 def verify_document_for_content(es_index, es_type, content):
     logging.info("Verifying content exists in Elasticsearch correctly. This could take several Elasticsearch requests.")
     start_time = time.time()
-    #flattened_content = flatten_dict(content)
-
-    logging.info("HERE IS THE CONTENT TO VERIFY:")
-    #logging.info(json.dumps(content))
-    logging.info(content)
-
-    
-
     content_json = json.loads(json.dumps(content))
-    for key, value in content_json.iteritems():
-        logging.info("KEY = " + key)
-        logging.info("   VALUE = " + value)
-        #if key == "fieldFormatMap":
-            #content_json[key] = replace_all_char(str=json.dumps(value), to_replace='\"', new_char='\\"')
-            #content_json[key] = json.dumps(value)
-	    #logging.info("NEW VALUE AT " + key + "=====")
-            #logging.info(content_json[key])
     to_verify = UTIL.copy_dict_keys(content_json)
     # There is approximately a one second delay between
     #   when a document is inserted and when it can be
@@ -120,17 +68,8 @@ def verify_document_for_content(es_index, es_type, content):
     #   try to reinsert it.
     while not all_keys_verified(to_verify) and not UTIL.time_has_run_out(start_time, time.time(), esUtil.ES_QUERY_TIMEOUT):
         for key in content_json.keys():
-        #for key in content.keys():
             if to_verify[key] != VERIFIED:
-		if key == 'fieldFormatMap':
-          	    logging.info("FIELD FORMAT MAP = ")
-                    logging.info(content_json[key])
-                    logging.info("NEW FIELD FORMAT MAP = ")
-                    logging.info(json.dumps(replace_all_char(str(content_json[key]), """\\""", """\\\\""")))
                 query = key + ':' + json.dumps(content_json[key]) 
-                logging.info("QUEREY ============================================= ")
-		logging.info(query) 
-                #query = key + ':' + '"'+ str(content[key]) + '"'
                 success, hits = esUtil.search_index_and_type(es_index, es_type, query)
                 if hits > 0:    
                     to_verify[key] = VERIFIED
@@ -162,24 +101,14 @@ def create_document_if_it_doesnt_exist(es_index, es_type, es_id, es_body):
 
 def get_field_mappings(filename):
     global index_pattern_content
-    mappings_json = UTIL.read_json_from_file(filename)
-    logging.info("OLD STRING = ")
-    logging.info(json.dumps(mappings_json))
-    value = UTIL.safe_list_read(mappings_json, 'fieldFormatMap')
-    logging.info("VALUE = ")
-    logging.info(json.dumps(value))
-    escaped_mappings = replace_all_char(str=json.dumps(value), to_replace='"', new_char='\"')
-    logging.info("NEW STRING =")
-    logging.info(json.dumps(escaped_mappings))
     corrected_mappings = {}
+    mappings_json = UTIL.read_json_from_file(filename)
+    value = UTIL.safe_list_read(mappings_json, 'fieldFormatMap')
+    # Quotations in the fieldFormatMap must be escaped
+    #   for proper Elasticsearch insertion
+    escaped_mappings = replace_all_char(str=json.dumps(value), to_replace='"', new_char='\"')
     corrected_mappings['fieldFormatMap'] = escaped_mappings
     index_pattern_content.update(corrected_mappings)
-    logging.info("NEW CONTENT TO UPDATE WITH:")
-    logging.info(json.dumps(index_pattern_content))
-    mappings_json = json.loads(json.dumps(index_pattern_content))
-    logging.info("HERE IS THE RESULT OF content[fieldFormatMap]")
-    logging.info(json.dumps(UTIL.safe_list_read(mappings_json, 'fieldFormatMap')))
-
 
 # ----------------- MAIN -----------------
 def main():

--- a/scripts/setDefaultIndex.py
+++ b/scripts/setDefaultIndex.py
@@ -4,7 +4,6 @@
 
 import time
 import json
-import sys
 from util import ElasticsearchUtil
 from util import Utility
 from util import Logger


### PR DESCRIPTION
Kibana apparently doesn't play nicely when the fieldFormatMap is inserted as explicit json objects. It would prefer that the key remain as ```"fieldFormatMap"```, but the value as a single string with escaped quotations. 

This issue was found after upgrading QA boxes. Whenever the ```Cannot locate field "byName" of undefined``` issue won't seem to go away, it points to a mismatch of Kibana keywords, or a malformed insertion of those keywords.