### PR TITLE
Add dependency on python-elasticsearch

### DIFF
--- a/packaging/kibana.spec
+++ b/packaging/kibana.spec
@@ -6,6 +6,7 @@ License:       https://github.com/joyent/node/blob/master/LICENSE
 Group:         Development/Tools
 URL:           https://github.com/joyent/%{name}
 Source:        http://nodejs.org/dist/v%{version}/%{name}-v{%version}.tar.gz
+Requires:      python-elasticsearch >= 1.0.0
 
 %description
 kibana build for logrhythm


### PR DESCRIPTION
So that all the python rpms in baseInstall will be installed on a fresh install