### PR TITLE
Fixed typeahead overlapping nav bar

### DIFF
--- a/src/kibana/components/typeahead/typeahead.less
+++ b/src/kibana/components/typeahead/typeahead.less
@@ -10,6 +10,7 @@
     color: @text-color;
     background-color: @body-bg;
     position: absolute;
+    top: 45px;
     z-index: @zindex-typeahead;
     width: 100%;
 


### PR DESCRIPTION
With fix (no error highlight):
![screen shot 2016-08-19 at 4 18 18 pm](https://cloud.githubusercontent.com/assets/10603412/17825863/a0dca958-6628-11e6-9281-96913eec5449.png)



With fix (error highlighting):
![screen shot 2016-08-19 at 4 18 33 pm](https://cloud.githubusercontent.com/assets/10603412/17825861/9cf131b0-6628-11e6-86bd-27b29c0ead46.png)