### PR TITLE
JWT Reworking for Kibana API requests

### DIFF
--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -57,12 +57,8 @@ define(function (require) {
       //    after (non-greedy) until either end of substring
       //    or the next ampersand.
       var jwtPattern = /jwt=(.*?)(&|$)/i;
-      var oneTrueJwt = String(hrefUrl).match(jwtPattern);
-      localStorage.setItem('token', oneTrueJwt[1]);
-      console.log("KIBANA: Full Url = **"+ fullUrl +"**");
-      console.log("KIBANA: Search Url = **"+ searchUrl +"**");
-      console.log("KIBANA: Href Url = **"+ hrefUrl +"**");
-      console.log("OFFICIAL JWT: **" + oneTrueJwt[1] + "**");
+      var jwt = String(hrefUrl).match(jwtPattern);
+      localStorage.setItem('token', jwt[1]);
       RestangularProvider.addResponseInterceptor(function(data, operation, what, url, response, deferred) {
          // TODO: standardized error handling - right now we soft fail errors to empty data
 
@@ -74,14 +70,10 @@ define(function (require) {
          return data && data.status === 'success' ? data.data : {error: true, message: data.message};
       });
       RestangularProvider.addFullRequestInterceptor(function() {
-         console.log("WE ARE IN THE FULL REQUEST INTERCEPTOR... CHECKING CACHE FOR TOKEN NOW!");
          const config = { headers: {} };
          const token = localStorage.getItem('token');
          if (token) {
-            console.log("The token is in the chache! attaching it to the headers...........");
-            console.log("The token is: **" + token + "**");
             config.headers['Authorization'] = token;
-            console.log("The AUTH header is: **" + config.headers['Authorization'] + "**");
          }
          return config;
       });

--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -58,6 +58,7 @@ define(function (require) {
       //    or the next ampersand.
       var jwtPattern = /jwt=(.*?)(&|$)/i;
       var oneTrueJwt = String(hrefUrl).match(jwtPattern);
+      localStorage.setItem('token', oneTrueJwt[1]);
       console.log("KIBANA: Full Url = **"+ fullUrl +"**");
       console.log("KIBANA: Search Url = **"+ searchUrl +"**");
       console.log("KIBANA: Href Url = **"+ hrefUrl +"**");
@@ -71,6 +72,14 @@ define(function (require) {
          }
 
          return data && data.status === 'success' ? data.data : {error: true, message: data.message};
+      });
+      RestangularProvider.addFullRequestInterceptor(function() {
+         const config = { headers: {} };
+         if (localStorage.getItem('token')) {
+            console.log("The token is in the chache! attaching it to the headers...........");
+            config.headers['Authorization'] = localStorage.getItem('token') || '';
+         }
+         return config;
       });
    })
     .config(['ngClipProvider', function (ngClipProvider) {

--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -11,7 +11,7 @@ define(function (require) {
   require('elasticsearch');
   require('angular-route');
   require('angular-bindonce');
-  
+
   require('restangular');
 
   var configFile = JSON.parse(require('text!config'));
@@ -53,40 +53,23 @@ define(function (require) {
       var searchUrl = window.location.search;
       var hrefUrl = window.location.href;
 
+      // Look for 'token=', then capture all characters
+      //    after (non-greedy) until either end of substring
+      //    or the next ampersand.
+      var jwtPattern = /jwt=(.*?)(&|$)/i;
+      var oneTrueJwt = String(hrefUrl).match(jwtPattern);
       console.log("KIBANA: Full Url = **"+ fullUrl +"**");
       console.log("KIBANA: Search Url = **"+ searchUrl +"**");
       console.log("KIBANA: Href Url = **"+ hrefUrl +"**");
-      var QueryString = function () {
-        // This function is anonymous, is executed immediately and 
-        // the return value is assigned to QueryString!
-        var query_string = {};
-        var query = window.location.search.substring(1);
-        var vars = query.split("&");
-        for (var i=0;i<vars.length;i++) {
-          var pair = vars[i].split("=");
-          // If first entry with this name
-          if (typeof query_string[pair[0]] === "undefined") {
-            query_string[pair[0]] = decodeURIComponent(pair[1]);
-          // If second entry with this name
-          } else if (typeof query_string[pair[0]] === "string") {
-            var arr = [ query_string[pair[0]],decodeURIComponent(pair[1]) ];
-            query_string[pair[0]] = arr;
-            // If third or later entry with this name
-          } else {
-            query_string[pair[0]].push(decodeURIComponent(pair[1]));
-          }
-        } 
-        return query_string;
-      }();
-      console.log("OFFICIAL JWT: **" + QueryString.token + "**");
+      console.log("OFFICIAL JWT: **" + oneTrueJwt[1] + "**");
       RestangularProvider.addResponseInterceptor(function(data, operation, what, url, response, deferred) {
          // TODO: standardized error handling - right now we soft fail errors to empty data
-      
+
          // Redirect API login failure response to login page
          if (data.status !== 'success' && data.message && data.message.match(/you must be logged in/gi)) {
             location.href = '/login.php';
          }
-      
+
          return data && data.status === 'success' ? data.data : {error: true, message: data.message};
       });
    })

--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -74,10 +74,14 @@ define(function (require) {
          return data && data.status === 'success' ? data.data : {error: true, message: data.message};
       });
       RestangularProvider.addFullRequestInterceptor(function() {
+         console.log("WE ARE IN THE FULL REQUEST INTERCEPTOR... CHECKING CACHE FOR TOKEN NOW!");
          const config = { headers: {} };
-         if (localStorage.getItem('token')) {
+         const token = localStorage.getItem('token');
+         if (token) {
             console.log("The token is in the chache! attaching it to the headers...........");
-            config.headers['Authorization'] = localStorage.getItem('token') || '';
+            console.log("The token is: **" + token + "**");
+            config.headers['Authorization'] = token;
+            console.log("The AUTH header is: **" + config.headers['Authorization'] + "**");
          }
          return config;
       });

--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -49,6 +49,36 @@ define(function (require) {
          'Pragma': 'no-cache',
          'Expires': 0
       });
+      var fullUrl = window.location;
+      var searchUrl = window.location.search;
+      var hrefUrl = window.location.href;
+
+      console.log("KIBANA: Full Url = **"+ fullUrl +"**");
+      console.log("KIBANA: Search Url = **"+ searchUrl +"**");
+      console.log("KIBANA: Href Url = **"+ hrefUrl +"**");
+      var QueryString = function () {
+        // This function is anonymous, is executed immediately and 
+        // the return value is assigned to QueryString!
+        var query_string = {};
+        var query = window.location.search.substring(1);
+        var vars = query.split("&");
+        for (var i=0;i<vars.length;i++) {
+          var pair = vars[i].split("=");
+          // If first entry with this name
+          if (typeof query_string[pair[0]] === "undefined") {
+            query_string[pair[0]] = decodeURIComponent(pair[1]);
+          // If second entry with this name
+          } else if (typeof query_string[pair[0]] === "string") {
+            var arr = [ query_string[pair[0]],decodeURIComponent(pair[1]) ];
+            query_string[pair[0]] = arr;
+            // If third or later entry with this name
+          } else {
+            query_string[pair[0]].push(decodeURIComponent(pair[1]));
+          }
+        } 
+        return query_string;
+      }();
+      console.log("OFFICIAL JWT: **" + QueryString.token + "**");
       RestangularProvider.addResponseInterceptor(function(data, operation, what, url, response, deferred) {
          // TODO: standardized error handling - right now we soft fail errors to empty data
       

--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -49,13 +49,11 @@ define(function (require) {
          'Pragma': 'no-cache',
          'Expires': 0
       });
-      var fullUrl = window.location;
-      var searchUrl = window.location.search;
-      var hrefUrl = window.location.href;
 
       // Look for 'token=', then capture all characters
       //    after (non-greedy) until either end of substring
       //    or the next ampersand.
+      var hrefUrl = window.location.href;
       var jwtPattern = /jwt=(.*?)(&|$)/i;
       var jwt = String(hrefUrl).match(jwtPattern);
       localStorage.setItem('token', jwt[1]);

--- a/src/kibana/netmon_libs/custom_modules/download/services/fileDownloader.js
+++ b/src/kibana/netmon_libs/custom_modules/download/services/fileDownloader.js
@@ -1,11 +1,11 @@
 define(function (require) {
-   
+
     var _ = require('lodash');
     var app = require('modules').get('netmon/download');
     app.factory('fileDownloader', function(Restangular, $timeout) {
         return {
              deDupeFiles : function(fileList) {
-                 
+
                  var countOccurences = function(fileList) {
                     var dupes = false;
                     var itemFreq = {};
@@ -20,7 +20,7 @@ define(function (require) {
                     if (dupes) return itemFreq;
                     return false;
                  };
-                 
+
                  var generateNamesForDupes = function(fileList) {
                     var dupes = countOccurences(fileList);
                     if (dupes){
@@ -45,11 +45,11 @@ define(function (require) {
                     }
                     return fileList;
                  };
-                 
+
                  return generateNamesForDupes(fileList);
              },
-             
-          
+
+
             formatFileNameForModal : function(fileName) {
                var lengthToTruncate = 35;
                if (fileName.length > lengthToTruncate){
@@ -58,15 +58,15 @@ define(function (require) {
               return fileName;
             },
             get: function(settings, type, sessionID){
-               
-    			 
+
+
                 var self = this;
                 var iframe = null;
 				var downloadID = null;
 				self.route = type + '/';
 				self.type = type;
 				self.postData = {file  : settings.fileList};
-				
+
 				settings.checkInterval = 500;
 				settings.fileUrl = '/data/api/' + self.route + '?action=download&downloadID=';
 
@@ -74,7 +74,7 @@ define(function (require) {
 				if (sessionID) {
 					self.postData.sessionID = sessionID;
 				}
-    				
+
                 var cancelDownload = function(downloadID) {
                     Restangular
                         .one(self.route)
@@ -83,12 +83,12 @@ define(function (require) {
 
                     settings.failCallback(
                         {
-                            header: 'Canceled', 
+                            header: 'Canceled',
                             body: 'Download canceled.',
                             class: 'modal-header alert alert-warning'
                         }, 'Canceled');
                 };
-                
+
 
                 var getiframeDocument = function(iframe) {
                     var iframeDoc = iframe.contentWindow || iframe.contentDocument;
@@ -127,7 +127,7 @@ define(function (require) {
                                         header: 'Failure',
                                         body: 'Download interrupted.',
                                         class: 'modal-header alert alert-danger'
-                                    },  'failure');  
+                                    },  'failure');
 
                             }
                             statusList = JSON.parse(statusList);
@@ -141,8 +141,8 @@ define(function (require) {
                                             header: 'Failure',
                                             body: 'One or more of the downloads failed.',
                                             class: 'modal-header alert alert-danger'
-                                        },  bulkStatus.bulkStatus);  
-                                } 
+                                        },  bulkStatus.bulkStatus);
+                                }
                                 iframe.contentWindow.stop();
                                 iframe.parentNode.removeChild(iframe);
                             } else {
@@ -167,14 +167,14 @@ define(function (require) {
                                             header: 'Failure',
                                             body: res.data.message,
                                             class: 'alert alert-danger'
-                                        },  'Error'); 
+                                        },  'Error');
                             } else {
                                 downloadID = res.downloadID;
                                 settings.fileUrl += downloadID;
-                                const token = localStorage.getItem('token');
+                                const jwt = localStorage.getItem('token');
                                 // If this fails, pcap download will be rejected.
-                                if (token) {
-                                  settings.fileUrl += "&token=" + token;
+                                if (jwt) {
+                                  settings.fileUrl += "&jwt=" + jwt;
                                 }
                                 settings.prepareCallback(settings.fileUrl);
                                 //create a temporary iframe that is used to request the fileUrl as a GET request

--- a/src/kibana/netmon_libs/custom_modules/download/services/fileDownloader.js
+++ b/src/kibana/netmon_libs/custom_modules/download/services/fileDownloader.js
@@ -171,6 +171,11 @@ define(function (require) {
                             } else {
                                 downloadID = res.downloadID;
                                 settings.fileUrl += downloadID;
+                                const token = localStorage.getItem('token');
+                                // If this fails, pcap download will be rejected.
+                                if (token) {
+                                  settings.fileUrl += "&token=" + token;
+                                }
                                 settings.prepareCallback(settings.fileUrl);
                                 //create a temporary iframe that is used to request the fileUrl as a GET request
                                 iframe = document.createElement('iframe');


### PR DESCRIPTION
The ONLY reasonably safe way for us to communicate our JWT from netmon www world to kibana is to pass it as a URL parameter when we display the iframe.

Now, when kibana gets the URL that we want to display, we will regex match the token as a string and save it in Kibana's domain cache (separate from www's domain cache).

In order to do pcap download, we use ANOTHER iframe to talk to www as a GET request. When we do this, again, we must pass the JWT in the iframe URL.

To read this off appropriately, I needed to add a function in our API class to 1) get the token from the HTTP headers if it is there and 2) look for it in the URL paramters if it is not.