### PR TITLE
Pass JWT in the Token header instead of Authorization

### DIFF
--- a/src/kibana/index.js
+++ b/src/kibana/index.js
@@ -63,7 +63,7 @@ define(function (require) {
          const config = { headers: {} };
          const token = localStorage.getItem('token');
          if (token) {
-            config.headers['Authorization'] = token;
+            config.headers['Token'] = token;
          }
          return config;
       });


### PR DESCRIPTION
THIS FIXES KIBANA SEARCHES

We use the Authorization header for basic auth now so Alex changed the token header in www.