### PR TITLE
Change systemd dependencies

### DIFF
--- a/systemd/kibana.service
+++ b/systemd/kibana.service
@@ -7,10 +7,6 @@ Wants=cassandra.service
 After=cassandra.service
 Wants=probemanager.service
 Before=probemanager.service
-Wants=probelogger.service
-Before=probelogger.service
-Wants=probereader.service
-Before=probereader.service
 Wants=probetransmogrifier.service
 Before=probetransmogrifier.service
 


### PR DESCRIPTION
ProbeReader and ProbeLogger are now started up after ProbeManager, rather than at the same time. Their dependencies have been removed from the kibana startup process.

Research: https://github.schq.secious.com/Logrhythm/Research/pull/1731