### PR TITLE
Exit with return code 1 to fail job

### DIFF
--- a/scripts/buildRpm.sh
+++ b/scripts/buildRpm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ $# -ne 1 ] ; then
     echo 'Usage:  sh buildRpm <KIBANA-OFFICIAL-BRANCH>'
-    exit 0
+    exit 1
 fi
 set -e
 set -x


### PR DESCRIPTION
If the wrong number of parameters are supplied, let's exit with return code 1 so Jenkins will fail the job.