### PR TITLE
Rotate KibanaStartup.log

### DIFF
--- a/scripts/loadAssets.py
+++ b/scripts/loadAssets.py
@@ -9,17 +9,19 @@ from os import listdir
 from os.path import isfile, join, splitext
 from util import ElasticsearchUtil
 from util import Utility
-from util import Logger
+from util import LogConfig
 es = Elasticsearch(max_retries=5, retry_on_timeout=True)
 esUtil = ElasticsearchUtil()
-logger = Logger()
-logging, rotating_handler = logger.configure_and_return_logging()
+logConfig = LogConfig()
+logging, rotating_handler = logConfig.configure_and_return_logging()
+logger = logging.getLogger()
+logger.addHandler(rotating_handler)
 UTIL = Utility()
 
 resources = "/usr/local/kibana-" + esUtil.KIBANA_VERSION + "-linux-x64/resources"
-dashboards_path = resources + "/dashboards" 
-visualizations_path = resources + "/visualizations" 
-searches_path = resources + "/searches" 
+dashboards_path = resources + "/dashboards"
+visualizations_path = resources + "/visualizations"
+searches_path = resources + "/searches"
 
 dashboard_type = "dashboard"
 visualization_type = "visualization"
@@ -43,17 +45,17 @@ def get_version_of_file(file):
     return version_from_file
 
 def update_existing_document(es_index, es_type, es_id, path_to_updated_json):
-    deleted, del_ret_val = esUtil.function_with_timeout(esUtil.ES_QUERY_TIMEOUT, 
+    deleted, del_ret_val = esUtil.function_with_timeout(esUtil.ES_QUERY_TIMEOUT,
                                                       esUtil.delete_document,
                                                         es_index,
                                                         es_type,
                                                         es_id)
-    logging.info("Delete returns: " + str(json.dumps(del_ret_val)))
+    logger.info("Delete returns: " + str(json.dumps(del_ret_val)))
     created, create_ret_val = create_document_from_file(es_index,
                                                       es_type,
                                                       es_id,
                                                       path_to_updated_json)
-    logging.info("Create returns: " + str(create_ret_val))
+    logger.info("Create returns: " + str(create_ret_val))
 
 def es_version_is_outdated(es_index, es_type, es_id, full_file_path):
     get_response_json = esUtil.get_request_as_json(es_index, es_type, es_id)
@@ -64,7 +66,7 @@ def es_version_is_outdated(es_index, es_type, es_id, full_file_path):
 
 def load_assets(es_index, es_type, path_to_files, files):
     for file in files:
-        logging.info("--------- " + file + " ---------")
+        logger.info("--------- " + file + " ---------")
         full_file_path = path_to_files + "/" + file
         es_id = get_es_id(file)
         ignored, asset_exists = esUtil.function_with_timeout(esUtil.ES_QUERY_TIMEOUT,
@@ -78,15 +80,15 @@ def load_assets(es_index, es_type, path_to_files, files):
                                                                                            es_id,
                                                                                            full_file_path)
             if es_outdated:
-                logging.info("File \"" + str(file) + "\" is outdated and requires update from version " + str(version_of_es_file) +
+                logger.info("File \"" + str(file) + "\" is outdated and requires update from version " + str(version_of_es_file) +
                              " to version " + str(version_of_disk_file) + ". Updating it now...")
                 update_existing_document(es_index, es_type, es_id, full_file_path)
             else:
-                logging.info("Current version of file \"" + str(file) + "\" in Elasticsearch is up-to-date. Version: " + str(version_of_es_file))
+                logger.info("Current version of file \"" + str(file) + "\" in Elasticsearch is up-to-date. Version: " + str(version_of_es_file))
         else:
-            logging.info("File \"" + str(file) + "\" doesn't exist in Elasticsearch. Creating it now...")
+            logger.info("File \"" + str(file) + "\" doesn't exist in Elasticsearch. Creating it now...")
             created, created_ret = create_document_from_file(es_index, es_type, es_id, full_file_path)
-            logging.info("Create returns: " + created_ret)
+            logger.info("Create returns: " + created_ret)
 
 
 # ----------------- MAIN -----------------
@@ -98,11 +100,11 @@ def main():
     searches = [filename for filename in listdir(searches_path) if isfile(join(searches_path, filename))]
 
     # Load all the artifacts appropriately
-    logging.info("================================== DASHBOARDS ==================================")
+    logger.info("================================== DASHBOARDS ==================================")
     load_assets(esUtil.KIBANA_INDEX, dashboard_type, dashboards_path, dashboards)
-    logging.info("================================== VISUALIZATIONS ==================================")
+    logger.info("================================== VISUALIZATIONS ==================================")
     load_assets(esUtil.KIBANA_INDEX, visualization_type, visualizations_path, visualizations)
-    logging.info("================================== SEARCHES ==================================")
+    logger.info("================================== SEARCHES ==================================")
     load_assets(esUtil.KIBANA_INDEX, search_type, searches_path, searches)
 
 if __name__ == '__main__':

--- a/scripts/setDefaultIndex.py
+++ b/scripts/setDefaultIndex.py
@@ -6,10 +6,10 @@ import time
 import json
 from util import ElasticsearchUtil
 from util import Utility
-from util import Logger
+from util import LogConfig
 esUtil = ElasticsearchUtil()
-logger = Logger()
-logging, rotating_handler = logger.configure_and_return_logging()
+logConfig = LogConfig()
+logging, rotating_handler = logConfig.configure_and_return_logging()
 logger = logging.getLogger()
 logger.addHandler(rotating_handler)
 UTIL = Utility()

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -4,7 +4,7 @@ import json
 import time
 import elasticsearch
 
-class Logger:
+class LogConfig:
   MAIN_LOG_FORMAT_STR='%(asctime)s.%(msecs)03d %(levelname)s:  %(message)s'
   MAIN_LOG_DATEFMT_STR='%Y/%m/%d %H:%M:%S'
   MAIN_LOG_PATH_DEFAULT='/var/log/probe/KibanaStartup.log'
@@ -58,7 +58,7 @@ class ElasticsearchUtil:
 
   def __init__(self, log_file=LOG_FILE):
     self.LOG_FILE = log_file
-    self.ES_LOGGER = Logger(self.LOG_FILE)
+    self.ES_LOGGER = LogConfig(self.LOG_FILE)
     self.logging, self.rotating_handler = self.ES_LOGGER.configure_and_return_logging()
     self.set_es_trace_logger()
     self.UTIL = Utility(log_file)
@@ -166,7 +166,7 @@ class Utility:
   rotating_handler = None
 
   def __init__(self, log_file=MAIN_LOG_PATH_DEFAULT):
-    self.LOGGER = Logger(log_file)
+    self.LOGGER = LogConfig(log_file)
     self.logging, self.rotating_handler = self.LOGGER.configure_and_return_logging()
 
   def make_json(self, content):

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -9,8 +9,8 @@ class Logger:
   MAIN_LOG_DATEFMT_STR='%Y/%m/%d %H:%M:%S'
   MAIN_LOG_PATH_DEFAULT='/var/log/probe/KibanaStartup.log'
   DEFAULT_LOGGING_LEVEL=10 # logging.DEBUG
-  DEFAULT_LOG_ROTATE_BYTES=10485760 # 10MB
-  DEFAULT_LOG_ROTATE_COUNT=5
+  DEFAULT_LOG_ROTATE_BYTES=52428800 # 50MB
+  DEFAULT_LOG_ROTATE_COUNT=3
 
   def __init__(self, log_file=MAIN_LOG_PATH_DEFAULT):
     self.MAIN_LOG_PATH_DEFAULT = log_file
@@ -23,7 +23,7 @@ class Logger:
         level=self.DEFAULT_LOGGING_LEVEL,
         format=format_str,
         datefmt=datefmt_str)
-    rotating_handler = logging.handlers.RotatingFileHandler(self.MAIN_LOG_PATH_DEFAULT, 
+    rotating_handler = logging.handlers.RotatingFileHandler(self.MAIN_LOG_PATH_DEFAULT,
                                                             maxBytes=self.DEFAULT_LOG_ROTATE_BYTES,
                                                             backupCount=self.DEFAULT_LOG_ROTATE_COUNT)
     return logging, rotating_handler
@@ -58,7 +58,7 @@ class ElasticsearchUtil:
 
   def __init__(self, log_file=LOG_FILE):
     self.LOG_FILE = log_file
-    self.ES_LOGGER = Logger(self.LOG_FILE) 
+    self.ES_LOGGER = Logger(self.LOG_FILE)
     self.logging, self.rotating_handler = self.ES_LOGGER.configure_and_return_logging()
     self.set_es_trace_logger()
     self.UTIL = Utility(log_file)
@@ -84,7 +84,7 @@ class ElasticsearchUtil:
     hits_json = self.UTIL.safe_list_read(search_response_json, 'hits')
     search_number_of_hits = self.UTIL.safe_list_read(hits_json, 'total')
     return True, search_number_of_hits
-  
+
   # Elasticsearch communication functions
   def create_document(self, es_index, es_type, es_id, es_body):
     es_create_ret = json.dumps(self.es.create(index=es_index,
@@ -98,11 +98,11 @@ class ElasticsearchUtil:
 
   def document_exists(self, es_index, es_type, es_id):
     exists_ret = self.es.exists(index=es_index, doc_type=es_type, id=es_id)
-    # es.exists returns a true or false. 
+    # es.exists returns a true or false.
     #   Always report that the function was successful,
     #   and leave the result in the second return value
     return True, exists_ret
-   
+
   def delete_document(self, es_index, es_type, es_id):
     es_del_raw = self.es.delete(index=es_index, doc_type=es_type, id=es_id)
     es_del_json = json.loads(json.dumps(es_del_raw))
@@ -168,7 +168,7 @@ class Utility:
   def __init__(self, log_file=MAIN_LOG_PATH_DEFAULT):
     self.LOGGER = Logger(log_file)
     self.logging, self.rotating_handler = self.LOGGER.configure_and_return_logging()
-  
+
   def make_json(self, content):
     return json.loads(json.dumps(content))
 
@@ -185,13 +185,13 @@ class Utility:
       return value
     except:
       self.logging.warning("No element in list for index: " + key)
-      return "" 
+      return ""
 
   def time_has_run_out(self, start, curr, max):
     return curr - start > max
 
   def read_json_from_file(self, filename):
-    with open(filename) as file_raw:    
+    with open(filename) as file_raw:
       return json.load(file_raw)
 
   def remove_all_char(self, string, to_remove):


### PR DESCRIPTION
Currently the KibanaStartup.log file grows unchecked every time the services are restarted. There was an attempt to set up log rotation with the python `logging` module, but I botched it. This fixes it, and will let the log grow to 50MB before swapping it out with a new one.

Note, the rotated logs are not tarred or zipped. Rather, there is another parameter that tells python to only keep 3 extra logs hanging around. The maximum the space the log files could take up would then be 200MB