### PR TITLE
Fixes moment deprecation warnings from kibana

### DIFF
--- a/src/kibana/components/timepicker/timepicker.js
+++ b/src/kibana/components/timepicker/timepicker.js
@@ -102,7 +102,7 @@ define(function (require) {
 
             break;
           case 'absolute':
-            $scope.absolute.from = datemath.parse($scope.from || moment().subtract('minutes', 15));
+            $scope.absolute.from = datemath.parse($scope.from || moment().subtract(15, 'minutes'));
             $scope.absolute.to = datemath.parse($scope.to || moment(), true);
             break;
           }

--- a/src/kibana/netmon_libs/custom_modules/save_rule/modal/modal.js
+++ b/src/kibana/netmon_libs/custom_modules/save_rule/modal/modal.js
@@ -34,7 +34,7 @@ define(function (require) {
          };
 
          $scope.openConfirmSaveRuleModal = function(rule, form) {
-            var from = moment().subtract('days', 1).toDate(),
+            var from = moment().subtract(1, 'days').toDate(),
                 to = moment().toDate();
 
             $scope.modalState.state = 'unconfirmed';

--- a/src/kibana/netmon_libs/custom_modules/save_rule/services/kbnIndexService.js
+++ b/src/kibana/netmon_libs/custom_modules/save_rule/services/kbnIndexService.js
@@ -63,19 +63,19 @@ define(function (require) {
              range.push(start.clone());
              switch (interval) {
                 case 'hour':
-                   start.add('hours',1);
+                   start.add(1,'hours');
                    break;
                 case 'day':
-                   start.add('days',1);
+                   start.add(1,'days');
                    break;
                 case 'week':
-                   start.add('weeks',1);
+                   start.add(1,'weeks');
                    break;
                 case 'month':
-                   start.add('months',1);
+                   start.add(1,'months');
                    break;
                 case 'year':
-                   start.add('years',1);
+                   start.add(1,'years');
                    break;
                 default:
                    break;


### PR DESCRIPTION
From Moment.js documentation:

Before version 2.8.0, the moment.subtract/add(String, Number) syntax was also supported. It has been deprecated in favor of moment.subtract/add(Number, String).

moment().subtract('seconds', 1); // Deprecated in 2.8.0
moment().subtract(1, 'seconds');

We're currently on version 2.13.0 so it's a preventative fix.

Goes with the [www PR](https://github.schq.secious.com/Logrhythm/www/pull/1304)
