### PR TITLE
Adds http search audit route to Kibana

### DIFF
--- a/src/kibana/netmon_libs/custom_modules/save_rule/services/searchAuditor.js
+++ b/src/kibana/netmon_libs/custom_modules/save_rule/services/searchAuditor.js
@@ -1,92 +1,90 @@
 define(function (require) {
-    var app = require('modules').get('app/dashboard');
-    var _ = require('lodash');
-    var moment = require('moment');
-    var angular = require('angular');
+   var app = require('modules').get('app/dashboard');
+   var _ = require('lodash');
+   var moment = require('moment');
+   var angular = require('angular');
+   var timefilter = require('components/timefilter/timefilter');
 
-    var timefilter = require('components/timefilter/timefilter');
-    app.factory('searchAuditor', function (elasticSearchFields,
-      Restangular, timefilter, $http) {
-         var FORMAT_STRING = 'YYYY/MM/DD HH:mm:ss';
-         var INDEX_PATTERN = '[network_]YYYY_MM_DD';
+   app.factory('searchAuditor', function (elasticSearchFields, Restangular, timefilter, $http) {
+      var FORMAT_STRING = 'YYYY/MM/DD HH:mm:ss';
+      var INDEX_PATTERN = '[network_]YYYY_MM_DD';
 
-         var previousQuery = {
-             query    : '',
-             fromDate : '',
-             toDate   : ''
+      var previousQuery = {
+         query    : '',
+         fromDate : '',
+         toDate   : ''
+      };
+
+      var formatQuery = function(query) {
+         var _query = _.isArray(query) ? query : [query];
+         if (_.isArray(_query)) {
+            var count = 0;
+            _.each(_query, function($q) {
+               $q = elasticSearchFields.convertQuery($q);
+               _query[count] = $q;
+               ++count;
+            });
+         } else {
+            _query = elasticSearchFields.convertQuery(_query);
+         }
+         return _query;
+      };
+
+      var logQuery = function(query) {
+      // ignore these searches for search auditing
+         var timeRange = timefilter.getBounds();
+         var timeFrom = timeRange.min;
+         var timeTo = timeRange.max;
+
+         if (!timeFrom || !timeTo) {
+            return;
+         }
+
+         timeFrom = moment(timeFrom).format(FORMAT_STRING);
+         timeTo = moment(timeTo).format(FORMAT_STRING);
+
+         if (query === previousQuery.query &&
+            timeFrom === previousQuery.fromDate &&
+            timeTo === previousQuery.toDate) {
+            return;
+         }
+         previousQuery = {
+            query    : query,
+            fromDate : timeFrom,
+            toDate   : timeTo
          };
-        var formatQuery = function(query) {
-            var _query = _.isArray(query) ? query : [query];
-            if (_.isArray(_query)) {
-                var count = 0;
-                _.each(_query, function($q) {
-                    $q = elasticSearchFields.convertQuery($q);
-                    _query[count] = $q;
-                    ++count;
-                });
 
-            } else {
-                _query = elasticSearchFields.convertQuery(_query);
-            }
-            return _query;
-        };
+         $http.put('/api/audit/search', 
+         { 
+            query: query,
+            from: timeFrom,
+            to: timeTo
+         })
+         .then(function (data) {}, 
+         function (error) {
+            var error = response.message || 'An unknown error occured';
+            console.log('Search Audit Error:', error);
+         });
+      };
 
-        var logQuery = function(query) {
-            // ignore these searches for search auditing
+      return {
+         logAndCapitalize : function(query) {
+            return elasticSearchFields.fetchMapping().then( function(hasFieldMap) {
+               var capitalizedQuery = formatQuery(query.query_string.query)[0];
+               logQuery(capitalizedQuery);
 
-            var timeRange = timefilter.getBounds();
-            var timeFrom = timeRange.min;
-            var timeTo = timeRange.max;
-
-            if (!timeFrom || !timeTo) {
-                return;
-            }
-
-            timeFrom = moment(timeFrom).format(FORMAT_STRING);
-            timeTo = moment(timeTo).format(FORMAT_STRING);
-
-            if (query === previousQuery.query &&
-                timeFrom === previousQuery.fromDate &&
-                timeTo === previousQuery.toDate) {
-                return;
-            }
-            previousQuery = {
-                query    : query,
-                fromDate : timeFrom,
-                toDate   : timeTo
-            };
-            $http.put('/api/audit/search', 
-               { 
-                  query: query,
-                  from: timeFrom,
-                  to: timeTo
-               })
-               .then(function (data) {},
-               function (error) {
-                  var error = response.message || 'An unknown error occured';
-                  console.log('Search Audit Error:', error);
-               });
-        };
-
-        return {
-            logAndCapitalize : function(query) {
-                return elasticSearchFields.fetchMapping().then( function(hasFieldMap) {
-                    var capitalizedQuery = formatQuery(query.query_string.query)[0];
-                    logQuery(capitalizedQuery);
-                    // seems like we need to create a new object to force angular to reflect the
-                    // query change in the view
-
-                   var newQuery =
-                      {
-                        query_string : {
-                           query : capitalizedQuery,
-                           analyze_wildcard : query.query_string.analyze_wildcard
-                      }
-                   };
-                   return newQuery;
-                });
-            }
-
-        };
-    });
+                // we create a new object to force angular to reflect the
+                // query change in the view
+               var newQuery =
+               {
+                  query_string : {
+                     query : capitalizedQuery,
+                     analyze_wildcard : query.query_string.analyze_wildcard
+                  }
+               };
+               return newQuery;
+            });
+         }
+      };
+   });
 });

--- a/src/kibana/netmon_libs/custom_modules/save_rule/services/searchAuditor.js
+++ b/src/kibana/netmon_libs/custom_modules/save_rule/services/searchAuditor.js
@@ -6,8 +6,9 @@ define(function (require) {
    var timefilter = require('components/timefilter/timefilter');
 
    app.factory('searchAuditor', function (elasticSearchFields, Restangular, timefilter, $http) {
-      var FORMAT_STRING = 'YYYY/MM/DD HH:mm:ss';
-      var INDEX_PATTERN = '[network_]YYYY_MM_DD';
+      const SEARCH_URI = '/api/audit/search';
+      const FORMAT_STRING = 'YYYY/MM/DD HH:mm:ss';
+      const INDEX_PATTERN = '[network_]YYYY_MM_DD';
 
       var previousQuery = {
          query    : '',
@@ -54,17 +55,19 @@ define(function (require) {
             toDate   : timeTo
          };
 
-         $http.put('/api/audit/search', 
+         $http.put(SEARCH_URI, 
          { 
             query: query,
             from: timeFrom,
             to: timeTo
          })
-         .then(function (data) {}, 
-         function (error) {
-            var error = response.message || 'An unknown error occured';
-            console.log('Search Audit Error:', error);
-         });
+         .then(
+            function (data) { }, 
+            function (error) {
+               var error = response.message || 'An unknown error occured';
+               console.log('Search Audit Error:', error);
+            }
+         );
       };
 
       return {

--- a/src/kibana/netmon_libs/custom_modules/save_rule/services/searchAuditor.js
+++ b/src/kibana/netmon_libs/custom_modules/save_rule/services/searchAuditor.js
@@ -6,7 +6,7 @@ define(function (require) {
 
     var timefilter = require('components/timefilter/timefilter');
     app.factory('searchAuditor', function (elasticSearchFields,
-      Restangular, timefilter) {
+      Restangular, timefilter, $http) {
          var FORMAT_STRING = 'YYYY/MM/DD HH:mm:ss';
          var INDEX_PATTERN = '[network_]YYYY_MM_DD';
 
@@ -55,19 +55,17 @@ define(function (require) {
                 fromDate : timeFrom,
                 toDate   : timeTo
             };
-            Restangular
-                .all('audit/')
-                .post({
-                    query    : query,
-                    from     : timeFrom,
-                    to       : timeTo
-                })
-                .then(function(response){
-                    if (response.error){
-                        var error = response.message || 'An unknown error occured';
-                        console.log('Search Audit Error:', error);
-                    }
-                });
+            $http.put('/api/audit/search', 
+               { 
+                  query: query,
+                  from: timeFrom,
+                  to: timeTo
+               })
+               .then(function (data) {},
+               function (error) {
+                  var error = response.message || 'An unknown error occured';
+                  console.log('Search Audit Error:', error);
+               });
         };
 
         return {


### PR DESCRIPTION
https://rally1.rallydev.com/#/10660867787d/detail/userstory/156595869908

- Removes the restangular call to the old search audit route and changes it to the new http route (/api/audit/search). 
- Fixes indentation in the file.

Goes with www PR: https://github.schq.secious.com/Logrhythm/www/pull/1325