### PR TITLE
Fix broken load-white.gif path

### DIFF
--- a/src/kibana/netmon_libs/custom_modules/download/modals/downloadStatus/downloadStatus.html
+++ b/src/kibana/netmon_libs/custom_modules/download/modals/downloadStatus/downloadStatus.html
@@ -8,7 +8,7 @@
          <tr ng-repeat="session in downloadModalManager.getFilesToDownload()">
             <td class="col-md-7">{{fileDownloader.formatFileNameForModal(session)}}</td>
             <td class="col-md-1">
-               <img src="/analyze/assets/img/load-white.gif" ng-if="downloadModalManager.getDownloadStatus(session) == 'downloading' || downloadModalManager.getDownloadStatus(session) == 'locating'"/>
+               <img src="/client/assets/img/load-white.gif" ng-if="downloadModalManager.getDownloadStatus(session) == 'downloading' || downloadModalManager.getDownloadStatus(session) == 'locating'"/>
                <i ng-if="downloadModalManager.getDownloadStatus(session) == 'waiting'" class="fa fa-clock-o"></i>
                <i ng-if="downloadModalManager.getDownloadStatus(session) === 'success'" class="fa fa-check"></i>
                <i ng-if="downloadModalManager.getDownloadStatus(session) === 'failure'" class="fa fa-exclamation-triangle"></i>

--- a/src/kibana/netmon_libs/custom_modules/save_rule/modal/modal.js
+++ b/src/kibana/netmon_libs/custom_modules/save_rule/modal/modal.js
@@ -10,7 +10,7 @@ define(function (require) {
     var _ = require('lodash');
 
     app.controller('SaveRuleController', function ($scope, $modalInstance, $http, query, formValidators, Restangular, ejsResource, kbnIndex, elasticSearchFields) {
-        $scope.loadingIconPath = '/analyze/assets/img/load-white.gif';
+        $scope.loadingIconPath = '/client/assets/img/load-white.gif';
         $scope.init = function(query){
            $scope.ejs = ejsResource('https://' + window.location.hostname);
            $scope.elasticSearchFields = elasticSearchFields;


### PR DESCRIPTION
- Update load-white.gif path for new folder structure in www

The load-white.gif can be seen when creating a query rule (while calculating how man hits there would be) or when downloading PCAPs (while finding them on disk).

Rally card - https://rally1.rallydev.com/#/10660867787d/detail/userstory/192706998276