### PR TITLE
[EsUpdateThreads Removal] Update Capture Dashboard with LatestUpdate:true and TimeStart gte 0

### DIFF
--- a/resources/dashboards/Capture-Dashboard.json
+++ b/resources/dashboards/Capture-Dashboard.json
@@ -1,11 +1,11 @@
 {
-   "title": "Capture Dashboard",
-   "hits": 0,
-   "description": "",
-   "panelsJSON": "[{\"col\":10,\"id\":\"Top-Applications-By-Bandwidth-(pie)\",\"row\":1,\"size_x\":3,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Top-Applications-By-Bandwidth-(histogram)\",\"row\":1,\"size_x\":9,\"size_y\":5,\"type\":\"visualization\"},{\"id\":\"Capture-Table\",\"type\":\"search\",\"size_x\":12,\"size_y\":4,\"col\":1,\"row\":6,\"columns\":[\"SrcIP\",\"DestIP\",\"Application\",\"Duration\",\"FlowCompleted\",\"Session\",\"Captured\"],\"sort\":[\"TimeUpdated\",\"desc\"]}]",
-   "version": 1,
-   "timeRestore": false,
+   "hits": 0, 
+   "timeRestore": false, 
+   "description": "", 
+   "title": "Capture Dashboard", 
+   "panelsJSON": "[{\"col\":10,\"id\":\"Top-Applications-By-Bandwidth-(pie)\",\"row\":1,\"size_x\":3,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Top-Applications-By-Bandwidth-(histogram)\",\"row\":1,\"size_x\":9,\"size_y\":5,\"type\":\"visualization\"},{\"id\":\"Capture-Table\",\"type\":\"search\",\"size_x\":12,\"size_y\":4,\"col\":1,\"row\":6,\"columns\":[\"SrcIP\",\"DestIP\",\"Application\",\"Duration\",\"FlowCompleted\",\"Session\",\"Captured\",\"LatestUpdate\"],\"sort\":[\"TimeUpdated\",\"desc\"]}]", 
+   "version": 1, 
    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Captured\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Captured\":{\"query\":true,\"type\":\"phrase\"}}}},{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Written\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Written\":{\"query\":true,\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
+      "searchSourceJSON": "{\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Captured\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Captured\":{\"query\":true,\"type\":\"phrase\"}}}},{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"Written\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"Written\":{\"query\":true,\"type\":\"phrase\"}}}},{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"LatestUpdate\",\"value\":\"true\",\"disabled\":false},\"query\":{\"match\":{\"LatestUpdate\":{\"query\":true,\"type\":\"phrase\"}}}},{\"meta\":{\"negate\":false,\"index\":\"[network_]YYYY_MM_DD\",\"key\":\"TimeStart\",\"value\":\"0\",\"disabled\":false},\"query\":{\"range\":{\"TimeStart\":{\"gte\":\"0\"}}}},{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
    }
 }


### PR DESCRIPTION
This value will get updated in Elasticsearch by the DiskCleanup thread, so that the Capture Dashboard only displays sessions that are truly captured.

Remove `LatestUpdate: true` from filters.