### PR TITLE
feat: upgrade nm-web-shared to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "^1.4.0",
+    "@logrhythm/nm-web-shared": "^1.5.0",
     "@logrhythm/webui": "^5.9.15",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash.clonedeep": "^4.5.4",

--- a/src/legacy/ui/public/chrome/directives/header_global_nav/components/header.tsx
+++ b/src/legacy/ui/public/chrome/directives/header_global_nav/components/header.tsx
@@ -269,7 +269,7 @@ class HeaderUI extends Component<Props, State> {
 
     return (
       <Fragment>
-        <Navbar />
+        <Navbar currentPage="analyze" />
 
         <EuiNavDrawer ref={this.navDrawerRef} data-test-subj="navDrawer">
           <EuiNavDrawerGroup listItems={recentLinksArray} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,10 +1767,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@^1.4.0":
-  version "1.4.0"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.4.0.tgz#605d3136bef8879b14ac1e6c9479043ef77490ae"
-  integrity sha1-YF0xNr74h5sUrB5slHkEPvd0kK4=
+"@logrhythm/nm-web-shared@^1.5.0":
+  version "1.5.0"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.5.0.tgz#011e87ad7117d21892a0bc3d07a151259efa4cfc"
+  integrity sha1-AR6HrXEX0hiSoLw9B6FRJZ76TPw=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"


### PR DESCRIPTION
This PR upgrades nm-web-shared to v1.5.0. See the [nm-web-shared changelog](https://github.com/logrhythm/nm-web-shared/blob/master/CHANGELOG.md#150) for the changes with this version!