### PR TITLE
Set the UI theme prior to serving the app

### DIFF
--- a/src/legacy/ui/ui_render/views/chrome.pug
+++ b/src/legacy/ui/ui_render/views/chrome.pug
@@ -1,7 +1,7 @@
 block vars
 
 doctype html
-html(lang=locale)
+html(lang=locale, class=darkMode ? 'Night' : 'Day')
   head
     meta(charset='utf-8')
     meta(http-equiv='X-UA-Compatible', content='IE=edge,chrome=1')


### PR DESCRIPTION
This PR sets the UI theme on the document root for the kibana app. That will prevent any UI flashing and will setup kibana for the changes made in [this `nm-web-shared` PR](https://github.com/logrhythm/nm-web-shared/pull/13).