### PR TITLE
upgrading shared to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "^1.8.1",
+    "@logrhythm/nm-web-shared": "^1.9.0",
     "@logrhythm/webui": "^5.9.15",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash.clonedeep": "^4.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,10 +1767,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@^1.8.1":
-  version "1.8.1"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.8.1.tgz#2e0129b1b01a4ee8ef7f2cf0537590f2d4447e85"
-  integrity sha1-LgEpsbAaTujvfyzwU3WQ8tREfoU=
+"@logrhythm/nm-web-shared@^1.9.0":
+  version "1.9.0"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.9.0.tgz#97e4a4aa96f8f66643012b4a2ae9896223f37cbd"
+  integrity sha1-l+Skqpb49mZDAStKKumJYiPzfL0=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"


### PR DESCRIPTION
Updating nm-web-shared version to 1.9.0.

See the changelog in nm-web-shared for the corresponding changes

Rally Ticket [US450](https://rally1.rallydev.com/#/331186074040d/detail/userstory/334639880308?fdp=true)