### PR TITLE
Updating nm-web-shared package to 1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "^1.10.0",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.7240b96296",
     "@logrhythm/webui": "^5.9.15",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash.clonedeep": "^4.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,10 +1767,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@^1.10.0":
-  version "1.10.0"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.10.0.tgz#7d8686afd3571f536cba0fc36a5625deafd3fae7"
-  integrity sha1-fYaGr9NXH1Nsug/DalYl3q/T+uc=
+"@logrhythm/nm-web-shared@1.0.0-dev.7240b96296":
+  version "1.0.0-dev.7240b96296"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.7240b96296.tgz#bdaba08f15a1056d0124b148b485c26a3395dc8a"
+  integrity sha1-vaugjxWhBW0BJLFItIXCajOV3Io=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"


### PR DESCRIPTION
This PR points `kibana` to the analyze and alarms dashboards correctly through the navbar by using it's ID.

NOTE: This PR will test [this `nm-web-shared` PR](https://github.com/logrhythm/nm-web-shared/pull/16)

SECOND NOTE: This PR uses a `dev` version of the `nm-web-shared` package for testing purposes. There is no need to pull the corresponding `nm-web-shared` PR, build it, and link it. 
The PR has already been packaged into a dev release and has been uploaded to the artifactory. The version has also been updated in the package.json here, so just running the `nm-web-app` build should get you the correct version of `nm-web-shared`.