### PR TITLE
feat: Refresh index pattern field cache on load

### DIFF
--- a/src/legacy/ui/public/index_patterns/index_patterns.js
+++ b/src/legacy/ui/public/index_patterns/index_patterns.js
@@ -51,7 +51,7 @@ export function IndexPatternsProvider(Private, config) {
   };
 
   self.make = function (id) {
-    return (new IndexPattern(id)).init();
+    return (new IndexPattern(id)).init(true);
   };
 
   self.delete = function (pattern) {


### PR DESCRIPTION
This PR will refresh the index pattern field cache when an index pattern is loaded. This means that a user only needs to refresh the page if they don't see a newly added field.

Also, anytime a user navigates to kibana, the index pattern will be refreshed.

NOTE: The index pattern will only be refreshed once per page load. This means that users will have to refresh to see any index pattern changes that occur WHILE they are using kibana.

On an unrelated note, this may be the smallest PR I have ever made.