### PR TITLE
Set token on response from the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.12.2",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.cd80ab1232",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.cd80ab1232",
+    "@logrhythm/nm-web-shared": "1.12.3",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.12.2":
-  version "1.12.2"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.12.2.tgz#27f18582ff457b08392a308444f10f3085f90fab"
-  integrity sha1-J/GFgv9Fewg5KjCERPEPMIX5D6s=
+"@logrhythm/nm-web-shared@1.0.0-dev.cd80ab1232":
+  version "1.0.0-dev.cd80ab1232"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.cd80ab1232.tgz#4da079fa730c23f588b93cd6f1048016b76109df"
+  integrity sha1-TaB5+nMMI/WIuTzW8QSAFrdhCd8=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.cd80ab1232":
-  version "1.0.0-dev.cd80ab1232"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.cd80ab1232.tgz#4da079fa730c23f588b93cd6f1048016b76109df"
-  integrity sha1-TaB5+nMMI/WIuTzW8QSAFrdhCd8=
+"@logrhythm/nm-web-shared@1.12.3":
+  version "1.12.3"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.12.3.tgz#2f88f72332c43f2f03fcf7163386b9517c729917"
+  integrity sha1-L4j3IzLEPy8D/PcWM4a5UXxymRc=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"


### PR DESCRIPTION
This PR reverts functionality to reset the auth token on every response from the server. This will fix issues with the client session timeout. Currently the session timeout starts the moment the user is logged in. With this change, that timeout will be based on inactivity.

This PR avoids the race condition of the initial code by checking if the user is currently authenticated before setting the token. This will prevent the case where the user logs out, then gets a server response, then resets the authentication.

[nm-web-shared PR](https://github.com/logrhythm/nm-web-shared/pull/21)
[nm-web-app PR](https://github.com/logrhythm/nm-web-app/pull/189)