### PR TITLE
feat: navbar shows list of dashboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.2ff6dcdcc5",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.7014f44cb5",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.7014f44cb5",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.8d13118226",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.8d13118226",
+    "@logrhythm/nm-web-shared": "1.15.0",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.14.2",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.2ff6dcdcc5",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.2ff6dcdcc5":
-  version "1.0.0-dev.2ff6dcdcc5"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.2ff6dcdcc5.tgz#766bc00c5ff58ec5b5285a82c7b0907ffbad28bb"
-  integrity sha1-dmvADF/1jsW1KFqCx7CQf/utKLs=
+"@logrhythm/nm-web-shared@1.0.0-dev.7014f44cb5":
+  version "1.0.0-dev.7014f44cb5"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.7014f44cb5.tgz#91adbb736fe17b83d3314dc90703fc28ebfdca75"
+  integrity sha1-ka27c2/he4PTMU3JBwP8KOv9ynU=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.7014f44cb5":
-  version "1.0.0-dev.7014f44cb5"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.7014f44cb5.tgz#91adbb736fe17b83d3314dc90703fc28ebfdca75"
-  integrity sha1-ka27c2/he4PTMU3JBwP8KOv9ynU=
+"@logrhythm/nm-web-shared@1.0.0-dev.8d13118226":
+  version "1.0.0-dev.8d13118226"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.8d13118226.tgz#8df624fbd00382407621af82482f14f25a894605"
+  integrity sha1-jfYk+9ADgkB2Ia+CSC8U8lqJRgU=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.14.2":
-  version "1.14.2"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.14.2.tgz#fd57298cb0988cc97f528c6481d5d5940b245e40"
-  integrity sha1-/VcpjLCYjMl/UoxkgdXVlAskXkA=
+"@logrhythm/nm-web-shared@1.0.0-dev.2ff6dcdcc5":
+  version "1.0.0-dev.2ff6dcdcc5"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.2ff6dcdcc5.tgz#766bc00c5ff58ec5b5285a82c7b0907ffbad28bb"
+  integrity sha1-dmvADF/1jsW1KFqCx7CQf/utKLs=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.8d13118226":
-  version "1.0.0-dev.8d13118226"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.8d13118226.tgz#8df624fbd00382407621af82482f14f25a894605"
-  integrity sha1-jfYk+9ADgkB2Ia+CSC8U8lqJRgU=
+"@logrhythm/nm-web-shared@1.15.0":
+  version "1.15.0"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.15.0.tgz#f0447b3ac69559fbfe487238c812b1c3d2f84c9b"
+  integrity sha1-8ER7OsaVWfv+SHI4yBKxw9L4TJs=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"


### PR DESCRIPTION
This PR updates the navbar to show a list of dashboards in the `Analyze` tab and removes the `Alarms` tab.

[nm-web-shared PR](https://github.com/logrhythm/nm-web-shared/pull/37)

![image](https://user-images.githubusercontent.com/10750197/68235387-63856100-ffc0-11e9-8fff-ec01c4097810.png)