### PR TITLE
fix: help links in navbar route correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.72ff507574",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.99eb62d338",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.14.2",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.6873d7f0c8",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.6873d7f0c8",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.a0927ac303",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.a0927ac303",
+    "@logrhythm/nm-web-shared": "1.0.0-dev.72ff507574",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@kbn/test-subj-selector": "0.2.1",
     "@kbn/ui-framework": "1.0.0",
     "@logrhythm/icons": "^1.19.0",
-    "@logrhythm/nm-web-shared": "1.0.0-dev.99eb62d338",
+    "@logrhythm/nm-web-shared": "1.15.1",
     "@logrhythm/webui": "^5.9.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.72ff507574":
-  version "1.0.0-dev.72ff507574"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.72ff507574.tgz#dd9a0b1a6fb68e13f16f00f091811dbca1a3cf47"
-  integrity sha1-3ZoLGm+2jhPxbwDwkYEdvKGjz0c=
+"@logrhythm/nm-web-shared@1.0.0-dev.99eb62d338":
+  version "1.0.0-dev.99eb62d338"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.99eb62d338.tgz#02de45500e05589f3232b2ec8ae694d472e39585"
+  integrity sha1-At5FUA4FWJ8yMrLsiuaU1HLjlYU=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.14.2":
-  version "1.14.2"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.14.2.tgz#fd57298cb0988cc97f528c6481d5d5940b245e40"
-  integrity sha1-/VcpjLCYjMl/UoxkgdXVlAskXkA=
+"@logrhythm/nm-web-shared@1.0.0-dev.6873d7f0c8":
+  version "1.0.0-dev.6873d7f0c8"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.6873d7f0c8.tgz#38f110a7079c379d0179f8c1c13574a2b2c6f260"
+  integrity sha1-OPEQpwecN50BefjBwTV0orLG8mA=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.a0927ac303":
-  version "1.0.0-dev.a0927ac303"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.a0927ac303.tgz#f7bf59eb1da7c810711a4f05936809a5db2dcc44"
-  integrity sha1-979Z6x2nyBBxGk8Fk2gJpdstzEQ=
+"@logrhythm/nm-web-shared@1.0.0-dev.72ff507574":
+  version "1.0.0-dev.72ff507574"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.72ff507574.tgz#dd9a0b1a6fb68e13f16f00f091811dbca1a3cf47"
+  integrity sha1-3ZoLGm+2jhPxbwDwkYEdvKGjz0c=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.99eb62d338":
-  version "1.0.0-dev.99eb62d338"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.99eb62d338.tgz#02de45500e05589f3232b2ec8ae694d472e39585"
-  integrity sha1-At5FUA4FWJ8yMrLsiuaU1HLjlYU=
+"@logrhythm/nm-web-shared@1.15.1":
+  version "1.15.1"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.15.1.tgz#318975551c7ea63770369e343a64912de59b774d"
+  integrity sha1-MYl1VRx+pjdwNp40OmSRLeWbd00=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/lucene-parser/-/@logrhythm/lucene-parser-3.4.0.tgz#19274929b73c83713c3597febe71a0c62ff2a5e9"
   integrity sha1-GSdJKbc8g3E8NZf+vnGgxi/ypek=
 
-"@logrhythm/nm-web-shared@1.0.0-dev.6873d7f0c8":
-  version "1.0.0-dev.6873d7f0c8"
-  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.6873d7f0c8.tgz#38f110a7079c379d0179f8c1c13574a2b2c6f260"
-  integrity sha1-OPEQpwecN50BefjBwTV0orLG8mA=
+"@logrhythm/nm-web-shared@1.0.0-dev.a0927ac303":
+  version "1.0.0-dev.a0927ac303"
+  resolved "https://logrhythm.jfrog.io/logrhythm/api/npm/npm-virtual/@logrhythm/nm-web-shared/-/@logrhythm/nm-web-shared-1.0.0-dev.a0927ac303.tgz#f7bf59eb1da7c810711a4f05936809a5db2dcc44"
+  integrity sha1-979Z6x2nyBBxGk8Fk2gJpdstzEQ=
 
 "@logrhythm/webui@^5.9.15":
   version "5.9.15"


### PR DESCRIPTION
This PR fixes the help links in the navbar. We don't need react-router links for these links because they direct the user to a completely different tab and application.

There are also some fixes for the `data-testid`s in the navbar.

[nm-web-shared PR](https://github.com/logrhythm/nm-web-shared/pull/38)