### PR TITLE
fix: hide attachment button when record is not captured

### DIFF
--- a/src/netmon/components/attach_download.tsx
+++ b/src/netmon/components/attach_download.tsx
@@ -33,10 +33,11 @@ const useStyles = createUseStyles({
 export interface AttachDownloadProps {
   session: string;
   fileName: string;
+  captured: boolean;
 }
 
 const AttachDownload = (props: AttachDownloadProps) => {
-  const { session, fileName } = props;
+  const { session, fileName, captured } = props;
 
   const classes = useStyles();
 
@@ -80,6 +81,10 @@ const AttachDownload = (props: AttachDownloadProps) => {
       return;
     }
   };
+
+  if (!captured) {
+    return fileName;
+  }
 
   return (
     <>

--- a/src/netmon/components/file_download/file_download_modal.tsx
+++ b/src/netmon/components/file_download/file_download_modal.tsx
@@ -42,7 +42,7 @@ import FileDownloadRow from './file_download_row';
 
 const useStyles = createUseStyles({
   modal: {
-    width: '600px',
+    minWidth: '600px',
   },
   footer: {
     display: 'flex',

--- a/src/netmon/components/file_download/file_download_modal.tsx
+++ b/src/netmon/components/file_download/file_download_modal.tsx
@@ -145,7 +145,7 @@ const FileDownloadModal = (props: FileDownloadModalProps) => {
                 <FileDownloadRow
                   key={`file_${f}`}
                   overallStatus={downloadStatus.overall}
-                  fileName={f}
+                  fileName={fileType === 'pcap' ? `${f}.pcap` : f}
                   fileStatus={downloadStatus.fileStatuses[f]}
                 />
               ))}

--- a/src/netmon/components/file_download/file_download_row.tsx
+++ b/src/netmon/components/file_download/file_download_row.tsx
@@ -72,10 +72,10 @@ const FileDownloadRow = (props: FileDownloadRowProps) => {
 
   const renderFileName = () => (
     <EuiTextColor color={fileStatus.status === 'failure' ? 'danger' : 'default'}>
-      {fileName.length < 38 && fileName}
-      {fileName.length >= 38 && (
+      {fileName.length < 42 && fileName}
+      {fileName.length >= 42 && (
         <EuiToolTip content={fileName}>
-          <div className={classes.tooltip}>{`${fileName.substr(0, 34)}...`}</div>
+          <div className={classes.tooltip}>{`${fileName.substr(0, 38)}...`}</div>
         </EuiToolTip>
       )}
     </EuiTextColor>

--- a/src/netmon/directives/attach_download_directive.js
+++ b/src/netmon/directives/attach_download_directive.js
@@ -29,6 +29,7 @@ module.directive('attachDownload', function (reactDirective) {
   return reactDirective(AttachDownload,
     [
       'session',
-      'fileName'
+      'fileName',
+      'captured'
     ]);
 });

--- a/src/netmon/field_formats/boolean_formats.ts
+++ b/src/netmon/field_formats/boolean_formats.ts
@@ -26,7 +26,9 @@ export const formatAttachDownload = (value: boolean, field: any, hit: any) => {
 
   const fileName = hit && hit._source && hit._source.Filename ? hit._source.Filename : '';
 
-  return `<attach-download session="'${session}'" fileName="'${fileName}'"></attach-download>`;
+  const captured = hit && hit._source && hit._source.Captured ? true : false;
+
+  return `<attach-download session="'${session}'" fileName="'${fileName}'" captured="${captured}"></attach-download>`;
 };
 
 export const formatCaptureDownload = (value: boolean, field: any, hit: any) => {


### PR DESCRIPTION
This PR hides the attachment button if the flow was not captured. If it wasn't captured, the attachment can't be downloaded, so users shouldn't be given the option to try a download at all.