### PR TITLE
test: add a class name on download rows

### DIFF
--- a/src/netmon/components/file_download/file_download_row.tsx
+++ b/src/netmon/components/file_download/file_download_row.tsx
@@ -18,6 +18,7 @@
  */
 
 import React from 'react';
+import classnames from 'classnames';
 import { makeStyles } from '@material-ui/core/styles';
 import _ from 'lodash';
 import { EuiHorizontalRule, EuiIcon, EuiProgress, EuiTextColor, EuiToolTip } from '@elastic/eui';
@@ -131,7 +132,9 @@ const FileDownloadRow = (props: FileDownloadRowProps) => {
   return (
     <React.Fragment>
       <div className={classes.fileDownloadItem}>
-        <span className={classes.fileDownloadText}>{renderFileName()}</span>
+        <span className={classnames(classes.fileDownloadText, 'fileDownloadText')}>
+          {renderFileName()}
+        </span>
         <span className={classes.fileDownloadProgress}>{renderFileStatus()}</span>
       </div>
       <EuiHorizontalRule />


### PR DESCRIPTION
This PR adds the `fileDownloadText` class to the rows in the file download modal.

This will enable automation testing to pick up the file text.