### PR TITLE
Wait for Kibana to be reachable before it reaches systemd 'active' status

### DIFF
--- a/packaging/kibana.spec
+++ b/packaging/kibana.spec
@@ -64,6 +64,7 @@ mkdir -p %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/scripts
 cp scripts/exportAssets.py %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/scripts
 cp scripts/configureKibana.py %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/scripts
 cp scripts/util.py %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/scripts
+cp scripts/kibana-post-start.sh %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/scripts
 cp -a plugins/ %{buildroot}/usr/local/%{name}-%{kibana_version}-linux-x64/
 
 mkdir -p %{buildroot}/usr/local/www/probe/

--- a/scripts/kibana-post-start.sh
+++ b/scripts/kibana-post-start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+KIBANA_STARTUP_LOG=/var/log/probe/KibanaStartup.log
+
+# Wait for KIBANA to become reachable
+echo "[INFO] Waiting for Kibana to become reachable" >> $KIBANA_STARTUP_LOG
+until /usr/bin/curl -I -XGET http://localhost:5601/analyze/status 2>/dev/null | grep -q "200"
+do
+   /usr/bin/sleep 1
+done
+echo "[INFO] Kibana is reachable and returned a 200 status" >> $KIBANA_STARTUP_LOG

--- a/systemd/kibana.service
+++ b/systemd/kibana.service
@@ -39,6 +39,7 @@ WorkingDirectory=/usr/local/kibana-7.5.2-linux-x64
 ExecStart=/usr/local/kibana-7.5.2-linux-x64/bin/kibana
 
 ExecStartPost=/usr/bin/python /usr/local/kibana-7.5.2-linux-x64/scripts/configureKibana.py
+ExecStartPost=/usr/bin/bash scripts/kibana-post-start.sh
 
 TimeoutStopSec=30
 


### PR DESCRIPTION
According to a Kibana source code comment, plugins can cause Kibana to start up too slowly (we are seeing this during upgrade, i.e., the first time Kibana has started up with a new plugin).

When that happens, the Kibana server returns a `503 Unavailable` and the message "Kibana server is not ready yet", which breaks automation tests and looks bad after the page unblocks from upgrade.

Added - a `kibana-post-start.sh` script, in the image of the Elasticsearch post start script. This hits the `localhost:5601/analyze/status` route, waiting for it to return a 200.

On initial startup, I have seen that route take up to 30 seconds before returning a 200. This would conceivably give the other services time to start before Kibana is truly ready.