### PR TITLE
Refresh the Kibana field mapping cache whenever the index pattern is loaded

### DIFF
--- a/src/legacy/core_plugins/data/public/index_patterns/index_patterns/index_patterns.ts
+++ b/src/legacy/core_plugins/data/public/index_patterns/index_patterns/index_patterns.ts
@@ -135,6 +135,6 @@ export class IndexPatterns {
       this.apiClient,
       indexPatternCache,
       this.notifications
-    ).init();
+    ).init(true);
   };
 }


### PR DESCRIPTION
This is the post-React conversion version of this PR: https://github.com/logrhythm/kibana/pull/122/files