### PR TITLE
Start all data stores before NetMon is started.

### DIFF
--- a/packaging/kibana.spec
+++ b/packaging/kibana.spec
@@ -71,6 +71,8 @@ mkdir -p %{buildroot}/usr/local/www/probe/
 ln -sf /usr/local/%{name}-%{kibana_version}-linux-x86_64 %{buildroot}/usr/local/www/probe/%{name}-%{kibana_version}-linux-x86_64
 
 %post
+# Disable the kibana.service first to clean up old dependency symlinks
+/usr/bin/systemctl disable kibana.service
 /usr/bin/systemctl enable kibana.service
 
 if [ -f "/usr/local/%{name}-%{kibana_version}-linux-x64/resources/visualization:Top-10-Dest-Ports-By-Flow-Count.json" ]

--- a/systemd/kibana.service
+++ b/systemd/kibana.service
@@ -5,10 +5,8 @@
 [Unit]
 Description=Kibana 7
 BindsTo=probemanager.service
-Wants=elasticsearch.service
-After=elasticsearch.service
-Wants=cassandra.service
-After=cassandra.service
+Wants=licenseserver.service
+After=licenseserver.service
 Wants=probemanager.service
 Before=probemanager.service
 Wants=probetransmogrifier.service
@@ -49,5 +47,5 @@ Restart=on-failure
 RestartSec=10
 
 [Install]
-WantedBy=elasticsearch.service
+WantedBy=netmon.service
 


### PR DESCRIPTION
See related pull requests:
logrhythm/nm-thirdparty#102
https://github.com/logrhythm/nm-core/pull/124
https://github.com/logrhythm/nm-license-server/pull/15